### PR TITLE
Fix return values/types of SpliceDDSTransport::check_[status/handle]

### DIFF
--- a/include/madara/transport/splice/SpliceDDSTransport.h
+++ b/include/madara/transport/splice/SpliceDDSTransport.h
@@ -1,5 +1,5 @@
 #ifndef _MADARA_SPLICE_DDS_TRANSPORT_H__
-#define _MADARA_SPLICE_DDS_TRANSPORT_H_
+#define _MADARA_SPLICE_DDS_TRANSPORT_H__
 
 #include <string>
 

--- a/include/madara/transport/splice/SpliceDDSTransport.h
+++ b/include/madara/transport/splice/SpliceDDSTransport.h
@@ -116,12 +116,12 @@ namespace madara
       /**
        * Splice handle checker
        **/
-      void check_handle (void * handle, const char *info);
+      int check_handle (void * handle, const char *info);
 
       /**
        * Splice status checker
        **/
-      void check_status (DDS::ReturnCode_t status, const char * info);
+      int check_status (DDS::ReturnCode_t status, const char * info);
       
       /**
        * Returns error name of the specific status


### PR DESCRIPTION
SpliceDDSTransport::check_status/check_handle were previously
using `exit(-2)` to exit the program. In commit 5f6d26e
`exit` was replaced by throwing the exception or returning the negative
value to the caller, including in these two methods. However, these
methods were left to be `void`.

This commit change the return type to be int and changes the usage
of these methods to check their return value.