### PR TITLE
Adding updates to local index after buffer overflows

### DIFF
--- a/include/madara/knowledge/containers/CircularBufferConsumer.inl
+++ b/include/madara/knowledge/containers/CircularBufferConsumer.inl
@@ -212,6 +212,13 @@ CircularBufferConsumer::inspect (
 
   KnowledgeRecord::Integer inserted = (KnowledgeRecord::Integer)count ();
 
+  // If buffer overflowed, update local index to last valid value - 1
+  KnowledgeRecord::Integer index_diff = (*index_ - local_index_);
+  if (index_diff > (KnowledgeRecord::Integer)buffer_.size ())
+  {
+    local_index_ = *index_ - (KnowledgeRecord::Integer)buffer_.size ();
+  }
+
   if ((position <= 0 && -position < inserted) ||
       (position > 0 && inserted == (KnowledgeRecord::Integer)size () &&
        position < inserted))
@@ -251,6 +258,13 @@ CircularBufferConsumer::inspect (
   check_context (__func__);
 
   ContextGuard context_guard (*context_);
+
+  // If buffer overflowed, update local index to last valid value - 1
+  KnowledgeRecord::Integer index_diff = (*index_ - local_index_);
+  if (index_diff > (KnowledgeRecord::Integer)buffer_.size ())
+  {
+    local_index_ = *index_ - (KnowledgeRecord::Integer)buffer_.size ();
+  }
 
   KnowledgeRecord::Integer inserted =
     (KnowledgeRecord::Integer)this->count ();
@@ -499,6 +513,13 @@ CircularBufferConsumer::consume_earliest (size_t count) const
   std::vector <KnowledgeRecord> result;
 
   KnowledgeRecord::Integer index_diff = (*index_ - local_index_);
+
+  // If buffer overflowed, update local index to last valid value - 1
+  if (index_diff > (KnowledgeRecord::Integer)buffer_.size ())
+  {
+    local_index_ = *index_ - (KnowledgeRecord::Integer)buffer_.size ();
+    index_diff = (KnowledgeRecord::Integer)buffer_.size ();
+  }
 
   count = std::min (count, (size_t)index_diff);
 

--- a/include/madara/knowledge/containers/CircularBufferConsumerT.inl
+++ b/include/madara/knowledge/containers/CircularBufferConsumerT.inl
@@ -465,7 +465,6 @@ CircularBufferConsumerT<T>::consume_earliest (size_t count,
   KnowledgeRecord::Integer index_diff = (*index_ - local_index_);
 
   // If buffer overflowed, update local index to last valid value - 1
-  KnowledgeRecord::Integer index_diff = (*index_ - local_index_);
   if (index_diff > (KnowledgeRecord::Integer)buffer_.size ())
   {
     local_index_ = *index_ - (KnowledgeRecord::Integer)buffer_.size ();

--- a/include/madara/knowledge/containers/CircularBufferConsumerT.inl
+++ b/include/madara/knowledge/containers/CircularBufferConsumerT.inl
@@ -228,6 +228,13 @@ CircularBufferConsumerT<T>::inspect (
 
   KnowledgeRecord::Integer inserted = (KnowledgeRecord::Integer)count ();
 
+  // If buffer overflowed, update local index to last valid value - 1
+  KnowledgeRecord::Integer index_diff = (*index_ - local_index_);
+  if (index_diff > (KnowledgeRecord::Integer)buffer_.size ())
+  {
+    local_index_ = *index_ - (KnowledgeRecord::Integer)buffer_.size ();
+  }
+
   if ((position <= 0 && -position < inserted) ||
       (position > 0 && inserted == (KnowledgeRecord::Integer)size () &&
        position < inserted))
@@ -258,6 +265,13 @@ CircularBufferConsumerT<T>::inspect (KnowledgeRecord::Integer position,
 
   KnowledgeRecord::Integer inserted =
     (KnowledgeRecord::Integer)this->count ();
+
+  // If buffer overflowed, update local index to last valid value - 1
+  KnowledgeRecord::Integer index_diff = (*index_ - local_index_);
+  if (index_diff > (KnowledgeRecord::Integer)buffer_.size ())
+  {
+    local_index_ = *index_ - (KnowledgeRecord::Integer)buffer_.size ();
+  }
 
   if ((position <= 0 && -position < inserted) ||
       (position > 0 && inserted == (KnowledgeRecord::Integer)size () &&
@@ -449,6 +463,14 @@ CircularBufferConsumerT<T>::consume_earliest (size_t count,
   ContextGuard context_guard (*context_);
 
   KnowledgeRecord::Integer index_diff = (*index_ - local_index_);
+
+  // If buffer overflowed, update local index to last valid value - 1
+  KnowledgeRecord::Integer index_diff = (*index_ - local_index_);
+  if (index_diff > (KnowledgeRecord::Integer)buffer_.size ())
+  {
+    local_index_ = *index_ - (KnowledgeRecord::Integer)buffer_.size ();
+    index_diff = (KnowledgeRecord::Integer)buffer_.size ();
+  }
 
   count = std::min (count, (size_t)index_diff);
 


### PR DESCRIPTION
If the buffer has overflowed, the local index will have to be updated so that it does not read invalid data. 