### PR TITLE
Updating how bounds checking works for ::inspect

### DIFF
--- a/include/madara/knowledge/containers/CircularBufferConsumer.inl
+++ b/include/madara/knowledge/containers/CircularBufferConsumer.inl
@@ -232,8 +232,8 @@ CircularBufferConsumer::inspect (
   {
     std::stringstream message;
     message << "CircularBufferConsumer::inspect: ";
-    message << "Invalid access for " << position << " element when buffer index is ";
-    message << *index_ << "\n";
+    message << "Invalid access for relative position " << position << " when buffer index is ";
+    message << *index_ << " and local index is : " << local_index_ << " and size is : " << size() << "\n";
     throw exceptions::IndexException (message.str ()); 
   }
 }
@@ -288,8 +288,8 @@ CircularBufferConsumer::inspect (
   {
     std::stringstream message;
     message << "CircularBufferConsumer::inspect: ";
-    message << "Invalid access for " << position << " element when buffer index is ";
-    message << *index_ << "\n";
+    message << "Invalid access for relative position " << position << " when buffer index is ";
+    message << *index_ << " and local index is : " << local_index_ << " and size is : " << size() << "\n";
     throw exceptions::IndexException (message.str ()); 
   }
 }

--- a/include/madara/knowledge/containers/CircularBufferConsumer.inl
+++ b/include/madara/knowledge/containers/CircularBufferConsumer.inl
@@ -210,8 +210,6 @@ CircularBufferConsumer::inspect (
 
   ContextGuard context_guard (*context_);
 
-  KnowledgeRecord::Integer inserted = (KnowledgeRecord::Integer)count ();
-
   // If buffer overflowed, update local index to last valid value - 1
   KnowledgeRecord::Integer index_diff = (*index_ - local_index_);
   if (index_diff > (KnowledgeRecord::Integer)buffer_.size ())
@@ -219,9 +217,11 @@ CircularBufferConsumer::inspect (
     local_index_ = *index_ - (KnowledgeRecord::Integer)buffer_.size ();
   }
 
-  if ((position <= 0 && -position < inserted) ||
-      (position > 0 && inserted == (KnowledgeRecord::Integer)size () &&
-       position < inserted))
+  KnowledgeRecord::Integer requested_index = local_index_ + position;
+
+  if (0 <= requested_index &&
+      (*index_ - (KnowledgeRecord::Integer)buffer_.size ()) <= requested_index &&
+      requested_index <= *index_)
   {
     size_t index = (size_t)increment (
       local_index_, (KnowledgeRecord::Integer)position);
@@ -232,8 +232,8 @@ CircularBufferConsumer::inspect (
   {
     std::stringstream message;
     message << "CircularBufferConsumer::inspect: ";
-    message << "Invalid access for " << position << " element when count is ";
-    message << inserted << "\n";
+    message << "Invalid access for " << position << " element when buffer index is ";
+    message << *index_ << "\n";
     throw exceptions::IndexException (message.str ()); 
   }
 }
@@ -266,12 +266,11 @@ CircularBufferConsumer::inspect (
     local_index_ = *index_ - (KnowledgeRecord::Integer)buffer_.size ();
   }
 
-  KnowledgeRecord::Integer inserted =
-    (KnowledgeRecord::Integer)this->count ();
+  KnowledgeRecord::Integer requested_index = local_index_ + position;
 
-  if ((position <= 0 && -position < inserted) ||
-      (position > 0 && inserted == (KnowledgeRecord::Integer)size () &&
-       position < inserted))
+  if (0 <= requested_index &&
+      (*index_ - (KnowledgeRecord::Integer)buffer_.size ()) <= requested_index &&
+      requested_index <= *index_)
   {
     KnowledgeRecord::Integer index = increment (
       local_index_, (KnowledgeRecord::Integer)position);
@@ -289,8 +288,8 @@ CircularBufferConsumer::inspect (
   {
     std::stringstream message;
     message << "CircularBufferConsumer::inspect: ";
-    message << "Invalid access for " << position << " element when count is ";
-    message << inserted << "\n";
+    message << "Invalid access for " << position << " element when buffer index is ";
+    message << *index_ << "\n";
     throw exceptions::IndexException (message.str ()); 
   }
 }

--- a/include/madara/knowledge/containers/CircularBufferConsumerT.inl
+++ b/include/madara/knowledge/containers/CircularBufferConsumerT.inl
@@ -226,8 +226,6 @@ CircularBufferConsumerT<T>::inspect (
 
   ContextGuard context_guard (*context_);
 
-  KnowledgeRecord::Integer inserted = (KnowledgeRecord::Integer)count ();
-
   // If buffer overflowed, update local index to last valid value - 1
   KnowledgeRecord::Integer index_diff = (*index_ - local_index_);
   if (index_diff > (KnowledgeRecord::Integer)buffer_.size ())
@@ -235,9 +233,11 @@ CircularBufferConsumerT<T>::inspect (
     local_index_ = *index_ - (KnowledgeRecord::Integer)buffer_.size ();
   }
 
-  if ((position <= 0 && -position < inserted) ||
-      (position > 0 && inserted == (KnowledgeRecord::Integer)size () &&
-       position < inserted))
+  KnowledgeRecord::Integer requested_index = local_index_ + position;
+
+  if (0 <= requested_index &&
+      (*index_ - (KnowledgeRecord::Integer)buffer_.size ()) <= requested_index &&
+      requested_index <= *index_)
   {
     size_t index = (size_t)increment (
       local_index_, (KnowledgeRecord::Integer)position);
@@ -248,8 +248,8 @@ CircularBufferConsumerT<T>::inspect (
   {
     std::stringstream message;
     message << "CircularBufferConsumerT<T>::inspect: ";
-    message << "Invalid access for " << position << " element when count is ";
-    message << inserted << "\n";
+    message << "Invalid access for " << position << " element when buffer index is ";
+    message << *index_ << "\n";
     throw exceptions::IndexException (message.str ()); 
   }
 }
@@ -263,9 +263,6 @@ CircularBufferConsumerT<T>::inspect (KnowledgeRecord::Integer position,
 
   ContextGuard context_guard (*context_);
 
-  KnowledgeRecord::Integer inserted =
-    (KnowledgeRecord::Integer)this->count ();
-
   // If buffer overflowed, update local index to last valid value - 1
   KnowledgeRecord::Integer index_diff = (*index_ - local_index_);
   if (index_diff > (KnowledgeRecord::Integer)buffer_.size ())
@@ -273,9 +270,11 @@ CircularBufferConsumerT<T>::inspect (KnowledgeRecord::Integer position,
     local_index_ = *index_ - (KnowledgeRecord::Integer)buffer_.size ();
   }
 
-  if ((position <= 0 && -position < inserted) ||
-      (position > 0 && inserted == (KnowledgeRecord::Integer)size () &&
-       position < inserted))
+  KnowledgeRecord::Integer requested_index = local_index_ + position;
+
+  if (0 <= requested_index &&
+      (*index_ - (KnowledgeRecord::Integer)buffer_.size ()) <= requested_index &&
+      requested_index <= *index_)
   {
     KnowledgeRecord::Integer index = increment (
       local_index_, (KnowledgeRecord::Integer)position);
@@ -289,8 +288,8 @@ CircularBufferConsumerT<T>::inspect (KnowledgeRecord::Integer position,
   {
     std::stringstream message;
     message << "CircularBufferConsumerT<T>::inspect: ";
-    message << "Invalid access for " << position << " element when count is ";
-    message << inserted << "\n";
+    message << "Invalid access for " << position << " element when buffer index is ";
+    message << *index_ << "\n";
     throw exceptions::IndexException (message.str ()); 
   }
 }

--- a/include/madara/knowledge/containers/CircularBufferConsumerT.inl
+++ b/include/madara/knowledge/containers/CircularBufferConsumerT.inl
@@ -247,9 +247,9 @@ CircularBufferConsumerT<T>::inspect (
   else
   {
     std::stringstream message;
-    message << "CircularBufferConsumerT<T>::inspect: ";
-    message << "Invalid access for " << position << " element when buffer index is ";
-    message << *index_ << "\n";
+    message << "CircularBufferConsumer::inspect: ";
+    message << "Invalid access for relative position " << position << " when buffer index is ";
+    message << *index_ << " and local index is : " << local_index_ << " and size is : " << size() << "\n";
     throw exceptions::IndexException (message.str ()); 
   }
 }
@@ -287,9 +287,9 @@ CircularBufferConsumerT<T>::inspect (KnowledgeRecord::Integer position,
   else
   {
     std::stringstream message;
-    message << "CircularBufferConsumerT<T>::inspect: ";
-    message << "Invalid access for " << position << " element when buffer index is ";
-    message << *index_ << "\n";
+    message << "CircularBufferConsumer::inspect: ";
+    message << "Invalid access for relative position " << position << " when buffer index is ";
+    message << *index_ << " and local index is : " << local_index_ << " and size is : " << size() << "\n";
     throw exceptions::IndexException (message.str ()); 
   }
 }

--- a/tests/test_karl_containers.cpp
+++ b/tests/test_karl_containers.cpp
@@ -2679,6 +2679,11 @@ void test_circular_consumer (void)
     std::cerr << "      inspect(-2) == " << consumer.inspect (-2) << "\n";
   }
 
+  for (KnowledgeRecord::Integer i = 0; i < 5; ++i)
+  {
+    producer.add (KnowledgeRecord (i + 105));
+  }
+
   std::cerr << "  Testing inspect(1)...";
 
   if (consumer.inspect (1) == 105)
@@ -2705,7 +2710,7 @@ void test_circular_consumer (void)
     std::cerr << "      inspect(2) == " << consumer.inspect (2) << "\n";
   }
 
-  std::cerr << "  Testing inspect(2,5)...";
+  std::cerr << "  Testing inspect(-2, 5)...";
 
   records = consumer.inspect (-2, 5);
 
@@ -2739,7 +2744,7 @@ void test_circular_consumer (void)
   for (KnowledgeRecord::Integer i = 0;
        !has_failed && i < (KnowledgeRecord::Integer)records.size (); ++i)
   {
-    if (records[i] != 124 - i)
+    if (records[i] != 109 - i)
     {
       has_failed = true;
       std::cerr << " Fail: records[" << i << "]=" << records[i] << "...";
@@ -3426,11 +3431,13 @@ void test_circular_consumer_any (void)
     }
   }
 
+  producer.add(classes);
+
   std::cerr << "  Testing inspect(1)...";
 
   consumer.inspect (1, class_result);
 
-  if (class_result.x == 0 && class_result.y == 0)
+  if (class_result.x == 9 && class_result.y == 9)
   {
     std::cerr << "SUCCESS\n";
   }
@@ -3667,9 +3674,11 @@ void test_circular_consumert_any (void)
 
   std::cerr << "  Testing inspect(1)...";
 
+  producer.add (classes);
+
   consumer.inspect (1, class_result);
 
-  if (class_result.x == 0 && class_result.y == 0)
+  if (class_result.x == 9 && class_result.y == 9)
   {
     std::cerr << "SUCCESS\n";
   }
@@ -3681,7 +3690,7 @@ void test_circular_consumert_any (void)
     std::cerr << "class_result.y==" << class_result.y << "\n";
   }
 
-  for (int i = 0; i < 10; ++i)
+  for (int i = 1; i < 10; ++i)
   {
     sample.x = i;
     sample.y = i;


### PR DESCRIPTION
Look at the requested index directly to ensure that valid data is returned. 