### PR TITLE
Marking size as modified and checking validity of records before casting

### DIFF
--- a/include/madara/knowledge/containers/CircularBuffer.h
+++ b/include/madara/knowledge/containers/CircularBuffer.h
@@ -349,6 +349,11 @@ namespace madara
         Vector buffer_;
 
         /**
+         * Reference to the size field of the vector space
+         **/
+        VariableReference size_ref_;
+
+        /**
          * Settings for modifications
          **/
         KnowledgeUpdateSettings settings_;

--- a/include/madara/knowledge/containers/CircularBuffer.inl
+++ b/include/madara/knowledge/containers/CircularBuffer.inl
@@ -200,6 +200,8 @@ CircularBuffer::add (
 
   context_->set (buffer_.vector_[(size_t)index], record, settings_);
 
+  context_->mark_modified (size_ref_);
+
   ++index_;
 }
 
@@ -231,6 +233,8 @@ CircularBuffer::add (
 
     context_->set (buffer_.vector_[(size_t)index], record, settings_);
   }
+
+  context_->mark_modified (size_ref_);
 
   index_ += (KnowledgeRecord::Integer)records.size ();
 }

--- a/include/madara/knowledge/containers/CircularBuffer.inl
+++ b/include/madara/knowledge/containers/CircularBuffer.inl
@@ -370,6 +370,8 @@ CircularBuffer::resize (int size)
   ContextGuard context_guard (*context_);
 
   buffer_.resize (size, false);
+
+  context_->mark_modified (size_ref_);
 }
 
 inline madara::knowledge::KnowledgeUpdateSettings
@@ -406,6 +408,7 @@ CircularBuffer::set_name (
     context_ = &(knowledge.get_context ());
     index_.set_name (name + ".index", knowledge);
     buffer_.set_name (name, knowledge);
+    size_ref_ = buffer_.get_size_ref ();
     if (buffer_.size () == 0 && index_ != -1)
     {
       index_ = -1;
@@ -429,6 +432,7 @@ CircularBuffer::set_name (const std::string & name,
     context_ = knowledge.get_context ();
     index_.set_name (name + ".index", knowledge);
     buffer_.set_name (name, knowledge);
+    size_ref_ = buffer_.get_size_ref ();
     if (buffer_.size () == 0 && index_ != -1)
     {
       index_ = -1;

--- a/include/madara/knowledge/containers/CircularBufferConsumer.inl
+++ b/include/madara/knowledge/containers/CircularBufferConsumer.inl
@@ -242,11 +242,17 @@ template <typename T> void
 CircularBufferConsumer::inspect (KnowledgeRecord::Integer position,
   size_t count, std::vector <T> & values) const
 {
+  uint64_t latest_toi = 0;
+
   // iterate over the returned records
   for (auto record : inspect (position, count))
   {
-    // add them to the values
-    values.push_back (record.to_any <T> ());
+    // add them to the values if valid and increasing toi
+    if (record.is_valid() && record.toi >= latest_toi)
+    {
+      latest_toi = record.toi;
+      values.push_back (record.to_any <T> ());
+    }
   }
 }
 
@@ -409,7 +415,8 @@ CircularBufferConsumer::consume_latest (size_t count,
   for (auto record : consume_latest (count))
   {
     // add them to the values
-    values.push_back (record.to_any <T> ());
+    if (record.is_valid())
+      values.push_back (record.to_any <T> ());
   }
 }
 
@@ -423,7 +430,8 @@ CircularBufferConsumer::consume_latest (size_t count,
   for (auto record : consume_latest (count))
   {
     // add them to the values
-    values.push_back (record.to_any <T> ());
+    if (record.is_valid())
+      values.push_back (record.to_any <T> ());
   }
 }
 
@@ -481,11 +489,16 @@ template <typename T> void
 CircularBufferConsumer::consume_earliest (size_t count,
   std::vector <T> & values) const
 {
+  uint64_t latest_toi = 0;
   // iterate over the returned records
   for (auto record : consume_earliest (count))
   {
-    // add them to the values
-    values.push_back (record.to_any <T> ());
+    // add them to the values if valid
+    if (record.is_valid() && record.toi >= latest_toi)
+    {
+      latest_toi = record.toi;
+      values.push_back (record.to_any <T> ());
+    }
   }
 }
 
@@ -495,11 +508,16 @@ CircularBufferConsumer::consume_earliest (size_t count,
 {
   dropped = get_dropped ();
 
+  uint64_t latest_toi = 0;
   // iterate over the returned records
   for (auto record : consume_earliest (count))
   {
-    // add them to the values
-    values.push_back (record.to_any <T> ());
+    // add them to the values if valid and increasing toi
+    if (record.is_valid() && record.toi >= latest_toi)
+    {
+      latest_toi = record.toi;
+      values.push_back (record.to_any <T> ());
+    }
   }
 }
 
@@ -597,7 +615,8 @@ CircularBufferConsumer::peek_latest (size_t count,
   for (auto record : peek_latest (count))
   {
     // add them to the values
-    values.push_back (record.to_any <T> ());
+    if (record.is_valid())
+      values.push_back (record.to_any <T> ());
   }
 }
 

--- a/include/madara/utility/LQueue.cpp
+++ b/include/madara/utility/LQueue.cpp
@@ -2,6 +2,7 @@
 #define _LQUEUE_CPP
 
 #include <memory>
+#include <algorithm>
 #include "madara/utility/LQueue.h"
 
 #ifdef _MSC_VER

--- a/include/madara/utility/LStack.cpp
+++ b/include/madara/utility/LStack.cpp
@@ -2,6 +2,7 @@
 #define _LSTACK_CPP_
 
 #include <memory>
+#include <algorithm>
 #include "madara/utility/LStack.h"
 
 #ifdef _MSC_VER


### PR DESCRIPTION
Updates to circular buffer to handle transport across two different KB. Specifically:

1. Mark buffer.size as modified so that it will be sent across the transport
2. Check validity of records before casting to any. This is to handle dropped messages. Also, use TOI as some basic check to make sure skipped data is not read. 