### PR TITLE
Add GetRecord

### DIFF
--- a/Tests.mpc
+++ b/Tests.mpc
@@ -190,6 +190,25 @@ project (Test_Fragmentation) : using_madara, no_karl, no_xml, null_lock, using_s
   }
 }
 
+project (Test_Get_Record) : using_madara, no_karl, no_xml, null_lock, using_simtime {
+  exeout = $(MADARA_ROOT)/bin
+  exename = test_get_record
+  
+  
+  requires += tests
+
+
+  Documentation_Files {
+  }
+  
+  Header_Files {
+  }
+
+  Source_Files {
+    tests/test_get_record.cpp
+  }
+}
+
 project (Test_Threader_Queue_Perf) : using_madara, no_karl, no_xml, null_lock, using_simtime {
   exeout = $(MADARA_ROOT)/bin
   exename = test_threader_queue_perf

--- a/include/madara/knowledge/GetRecord.h
+++ b/include/madara/knowledge/GetRecord.h
@@ -2,7 +2,7 @@
  * @file GetRecord.h
  * @author Sam Khalandovsky <sam.khalandovsky@shield.ai>
  *
- * This file provides functions to get KnowledgeRecord data without impilicit conversions
+ * This file provides functions to get KnowledgeRecord data without implicit conversions
  **/
 
 #ifndef _MADARA_KNOWLEDGE_GET_RECORD_H_

--- a/include/madara/knowledge/GetRecord.h
+++ b/include/madara/knowledge/GetRecord.h
@@ -1,0 +1,136 @@
+/**
+ * @file GetRecord.h
+ * @author Sam Khalandovsky <sam.khalandovsky@shield.ai>
+ *
+ * This file provides functions to get KnowledgeRecord data without impilicit conversions
+ **/
+
+#ifndef _MADARA_KNOWLEDGE_GET_RECORD_H_
+#define _MADARA_KNOWLEDGE_GET_RECORD_H_
+
+#include <madara/knowledge/KnowledgeRecord.h>
+#include <madara/knowledge/KnowledgeCast.h>
+#include <madara/utility/SupportTest.h>
+
+#include "madara/exceptions/MadaraException.h"
+
+namespace madara
+{
+  namespace exceptions
+  {
+    /**
+     * A base class for exceptions thrown by knowledge::get
+     **/
+    class InvalidGetException : public MadaraException
+    {
+    public:
+      using MadaraException::MadaraException;
+    };
+
+    /**
+     * Exception thrown when a attempting to retrieve a value from an empty record
+     */
+    class MissingValueException : public InvalidGetException
+    {
+    public:
+      using InvalidGetException::InvalidGetException;
+    };
+
+    /**
+     * Exception thrown when attempting to retrieve a value from a record of the wrong type
+     */
+    class MismatchedTypeException : public InvalidGetException
+    {
+    public:
+      using InvalidGetException::InvalidGetException;
+    };
+  }
+}
+
+namespace madara { namespace knowledge {
+
+#ifdef DOXYGEN
+
+/**
+ * @brief Check if a KnowledgeRecord type matches a specified type
+ * 
+ * @param t an instance of the type helper struct to infer the target type
+ * @param in the KnowledgeRecord to read from
+ * @return true if the types match
+ */
+template <typename T>
+inline bool type_match(type<T> t, const KnowledgeRecord &kr);  
+#else
+
+template <typename T>
+inline auto type_match(type<T>, const KnowledgeRecord &kr) -> 
+  typename std::enable_if<std::is_integral<T>::value, bool>::type
+{
+  return kr.type() == KnowledgeRecord::INTEGER;
+}
+
+template <typename T>
+inline auto type_match(type<T>, const KnowledgeRecord &kr) -> 
+  typename std::enable_if<std::is_floating_point<T>::value, bool>::type
+{
+  return kr.type() == KnowledgeRecord::DOUBLE;
+}
+
+inline bool type_match(type<std::string>, const KnowledgeRecord &kr) 
+{
+  return kr.type() == KnowledgeRecord::STRING;
+}
+
+template<typename T>
+inline auto type_match(type<std::vector<T>>, const KnowledgeRecord &kr) ->
+  typename std::enable_if<std::is_integral<T>::value, bool>::type
+{
+  return kr.type() == KnowledgeRecord::INTEGER_ARRAY;
+}
+
+template<typename T>
+inline auto type_match(type<std::vector<T>>, const KnowledgeRecord &kr) ->
+  typename std::enable_if<std::is_floating_point<T>::value, bool>::type
+{
+  return kr.type() == KnowledgeRecord::DOUBLE_ARRAY;
+}
+
+#endif // DOXYGEN
+
+/**
+ * @brief Get the value of a KnowlegeRecord
+ * 
+ * INTEGER records can be retrieved as any integral type (bool, int, uint, etc)
+ * DOUBLE records can be retrieved as any floating point type (double, float)
+ * STRING records can be retrieved as std::string
+ * INTEGER_ARRAY and DOUBLE_ARRAY can be retreived as an std::vector of integral 
+ *    or floating point types respectively.
+ * 
+ * @throws MissingValueException if the Record in empty
+ * @throws MismatchedTypeException if template type does not match stored type
+ * 
+ * @tparam T type of expected value
+ * @param kr Record to read from
+ * @return the stored value
+ */
+template <typename T>
+inline T get(const KnowledgeRecord &kr)
+{
+  if(!kr.exists())
+  {
+    throw exceptions::MissingValueException("madara::knowledge::get: "
+      "KnowledgeRecord does not exist");
+  }
+  if(!type_match(type<T>{}, kr))
+  {
+    throw exceptions::MismatchedTypeException("madara::knowledge::get: "
+      "Expected type does not match the KnowledgeRecord's type (" + std::to_string(kr.type()) + ")");
+  }
+
+  return knowledge_cast<T>(kr);
+}
+
+} // namespace knowledge
+} // namespace madara
+
+#endif  // _MADARA_KNOWLEDGE_GET_RECORD_H_

--- a/tests/test_get_record.cpp
+++ b/tests/test_get_record.cpp
@@ -1,0 +1,66 @@
+
+#include "madara/knowledge/KnowledgeRecord.h"
+#include "madara/knowledge/GetRecord.h"
+
+#include "test.h"
+
+using namespace madara::knowledge;
+using namespace madara::exceptions;
+
+#define EXPECT_EXCEPTION(exception_type, expr) \
+  try { \
+    (expr); \
+    log("FAIL    : %s did not throw %s\n", #expr, #exception_type); \
+    madara_tests_fail_count++; \
+  } catch (exception_type e) { \
+    log("SUCCESS : %s threw %s\n", #expr, #exception_type); \
+  }
+
+
+int main(){
+  KnowledgeRecord kr_int(4);
+  TEST_EQ(4, get<int>(kr_int));
+  TEST_EQ(4, get<char>(kr_int));
+  TEST_EQ(true, get<bool>(kr_int));
+
+  EXPECT_EXCEPTION(MissingValueException, get<int>(KnowledgeRecord()));
+  EXPECT_EXCEPTION(MismatchedTypeException, get<int>(KnowledgeRecord(2.0)));
+  EXPECT_EXCEPTION(MismatchedTypeException, get<int>(KnowledgeRecord("test")));
+
+  KnowledgeRecord kr_double(4.0);
+  TEST_EQ(4.0, get<double>(kr_double));
+  TEST_EQ(4.0, get<float>(kr_double));
+
+  EXPECT_EXCEPTION(MissingValueException, get<double>(KnowledgeRecord()));
+  EXPECT_EXCEPTION(MismatchedTypeException, get<double>(KnowledgeRecord(2)));
+  EXPECT_EXCEPTION(MismatchedTypeException, get<int>(KnowledgeRecord("test")));
+
+  TEST_EQ("test", get<std::string>(KnowledgeRecord("test")));
+
+  std::vector<double> double_arr {1.2, 1.4};
+  KnowledgeRecord kr_double_arr(double_arr);
+  get<std::vector<double>>(kr_double_arr);
+  get<std::vector<float>>(kr_double_arr);
+  EXPECT_EXCEPTION(MismatchedTypeException, get<std::vector<int>>(kr_double_arr));
+  EXPECT_EXCEPTION(MismatchedTypeException, get<double>(kr_double_arr));
+
+  std::vector<int64_t> int_arr {1, 4};
+  KnowledgeRecord kr_int_arr(int_arr);
+  get<std::vector<int>>(kr_int_arr);
+  get<std::vector<bool>>(kr_int_arr);
+  EXPECT_EXCEPTION(MismatchedTypeException, get<std::vector<double>>(kr_int_arr));
+  EXPECT_EXCEPTION(MismatchedTypeException, get<int>(kr_int_arr));
+
+  if (madara_tests_fail_count > 0)
+  {
+    std::cerr << "OVERALL: FAIL. " << madara_tests_fail_count <<
+      " tests failed.\n";
+  }
+  else
+  {
+    std::cerr << "OVERALL: SUCCESS.\n";
+  }
+
+  return madara_tests_fail_count;
+
+}


### PR DESCRIPTION
Adds a function `madara::knowledge::get<T>(const KnowledgeRecord& kr)` which attempts to return the data in the knowledge record as a type T, but throws exceptions if the KR is empty, or if an implicit conversion is required between strings, integral types, or floating point types.