### PR TITLE
Circular buffer and Streaming features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,6 +148,7 @@ script:
   - $MADARA_ROOT/bin/test_bandwidth_monitor
   - $MADARA_ROOT/bin/test_basic_reasoning
   - $MADARA_ROOT/bin/test_checkpointing
+  - $MADARA_ROOT/bin/test_circular_buffer
   - $MADARA_ROOT/bin/test_context_copy
   - $MADARA_ROOT/bin/test_encoding
   - $MADARA_ROOT/bin/test_filters

--- a/Tests.mpc
+++ b/Tests.mpc
@@ -1483,7 +1483,7 @@ project (Test_Any_So) : using_madara, no_karl, no_xml, null_lock, using_simtime 
 
   after += Test_Datatypes_Lib
 
-  libs += datatypes_test
+  libs += datatypes_shared
 
   Documentation_Files {
   }
@@ -1493,5 +1493,22 @@ project (Test_Any_So) : using_madara, no_karl, no_xml, null_lock, using_simtime 
 
   Source_Files {
     tests/test_any_so.cpp
+  }
+}
+
+project (Test_Circular_Buffer) : using_madara, no_karl, no_xml, null_lock, using_simtime {
+  requires += tests
+  
+  exeout = $(MADARA_ROOT)/bin
+  exename = test_circular_buffer
+  
+  Documentation_Files {
+  }
+
+  Header_Files {
+  }
+
+  Source_Files {
+    tests/test_circular_buffer.cpp
   }
 }

--- a/Tests.mpc
+++ b/Tests.mpc
@@ -1483,7 +1483,7 @@ project (Test_Any_So) : using_madara, no_karl, no_xml, null_lock, using_simtime 
 
   after += Test_Datatypes_Lib
 
-  libs += datatypes_shared
+  libs += datatypes_test
 
   Documentation_Files {
   }

--- a/include/madara/knowledge/BaseStreamer.h
+++ b/include/madara/knowledge/BaseStreamer.h
@@ -13,11 +13,23 @@
 
 namespace madara { namespace knowledge {
 
+/**
+ * Interface for knowledge update streaming. Objects which implement this
+ * interface can be attachecd to a KnowledgeBase with the attach_streamer
+ * method to receive copies of every modification of knowledge.
+ **/
 class MADARA_EXPORT BaseStreamer
 {
 public:
   virtual ~BaseStreamer() = default;
 
+  /**
+   * When attached to a KnowledgeBase, this will be called every time a
+   * KnowledgeRecord held within is modified.
+   *
+   * @param name the variable name of the KnowledgeRecord
+   * @param record a copy of the new value
+   **/
   virtual void enqueue(std::string name, KnowledgeRecord record) = 0;
 };
 

--- a/include/madara/knowledge/BaseStreamer.h
+++ b/include/madara/knowledge/BaseStreamer.h
@@ -1,0 +1,26 @@
+#ifndef MADARA_KNOWLEDGE_BASE_STREAMER_H_
+#define MADARA_KNOWLEDGE_BASE_STREAMER_H_
+
+#include "madara/MadaraExport.h"
+
+/**
+ * @file BaseStreamer.h
+ * @author David Kyle <david.kyle@shield.ai>
+ *
+ * This file contains the BaseStream base interface class for knowledge
+ * streamers.
+ **/
+
+namespace madara { namespace knowledge {
+
+class MADARA_EXPORT BaseStreamer
+{
+public:
+  virtual ~BaseStreamer() = default;
+
+  virtual void enqueue(std::string name, KnowledgeRecord record) = 0;
+};
+
+} } // namespace madara::knowledge
+
+#endif // MADARA_KNOWLEDGE_BASE_STREAMER_H_

--- a/include/madara/knowledge/CheckpointStreamer.cpp
+++ b/include/madara/knowledge/CheckpointStreamer.cpp
@@ -1,0 +1,114 @@
+/**
+ * @file CheckpointStreamer.cpp
+ * @author David Kyle <david.kyle@shield.ai>
+ *
+ * This file contains the CheckpointStream class which streams knowledge updates
+ * to serialized temporal knowledge (STK) checkpoints.
+ **/
+
+#include <chrono>
+
+#include "CheckpointStreamer.h"
+
+#include "madara/logger/Logger.h"
+#include "madara/knowledge/ContextGuard.h"
+
+namespace sc = std::chrono;
+
+namespace madara { namespace knowledge {
+
+void CheckpointStreamer::enqueue(std::string name, KnowledgeRecord record)
+{
+  ContextGuard context_guard (*context_);
+
+  in_buffer.emplace_back(std::move(name), std::move(record));
+}
+
+namespace {
+  class CheckpointStreamerLister : public VariablesLister
+  {
+  public:
+    using pair_type = std::pair<std::string, KnowledgeRecord>;
+    using vector_type = std::vector<pair_type>;
+    using iterator_type = vector_type::const_iterator;
+
+    CheckpointStreamerLister(const vector_type &vec) :
+      vec_(&vec) {}
+
+    void start(const CheckpointSettings &settings) override
+    {
+      (void)settings;
+      iter_ = vec_->begin();
+    }
+
+    std::pair<const char *, const KnowledgeRecord *> next() override
+    {
+      std::pair<const char *, const KnowledgeRecord *> ret{nullptr, nullptr};
+
+      if (iter_ == vec_->end()) {
+        return ret;
+      }
+
+      ret.first = iter_->first.c_str();
+      ret.second = &iter_->second;
+
+      ++iter_;
+
+      return ret;
+    }
+
+  private:
+    const vector_type *vec_;
+    iterator_type iter_;
+  };
+}
+
+void CheckpointStreamer::thread_main(CheckpointStreamer *self)
+{
+  auto period = sc::microseconds(int64_t(1000000 / self->write_hertz_));
+  auto wakeup = sc::steady_clock::now() + period;
+
+  madara_logger_log (self->context_->get_logger(), logger::LOG_MINOR,
+    "CheckpointStreamer::thread_main:" \
+    " created thread at %f hertz (%d ns period)\n",
+    self->write_hertz_,
+    sc::duration_cast<sc::nanoseconds>(period).count());
+
+  self->settings_.variables_lister = nullptr;
+
+  while (self->keep_running_.test_and_set()) {
+    {
+      ContextGuard context_guard (*self->context_);
+
+      using std::swap;
+      swap(self->in_buffer, self->out_buffer);
+
+      madara_logger_log (self->context_->get_logger(), logger::LOG_TRACE,
+        "CheckpointStreamer::thread_main:" \
+        " woke up after %d ns and found %d updates\n",
+        sc::duration_cast<sc::nanoseconds>(period).count(),
+        self->out_buffer.size());
+    }
+
+    if (self->out_buffer.size() > 0) {
+      CheckpointStreamerLister lister{self->out_buffer};
+      self->settings_.variables_lister = &lister;
+
+      self->context_->save_checkpoint(self->settings_);
+
+      self->settings_.variables_lister = nullptr;
+
+      self->out_buffer.clear();
+    }
+
+    std::this_thread::sleep_until(wakeup);
+    wakeup += period;
+  }
+}
+
+CheckpointStreamer::~CheckpointStreamer()
+{
+  terminate();
+}
+
+} } // namespace madara::knowledge

--- a/include/madara/knowledge/CheckpointStreamer.h
+++ b/include/madara/knowledge/CheckpointStreamer.h
@@ -1,0 +1,78 @@
+#ifndef MADARA_KNOWLEDGE_CHECKPOINT_STREAMER_H_
+#define MADARA_KNOWLEDGE_CHECKPOINT_STREAMER_H_
+
+#include <memory>
+#include <vector>
+#include <thread>
+#include <atomic>
+#include <chrono>
+
+#include "madara/MadaraExport.h"
+#include "madara/knowledge/CheckpointSettings.h"
+#include "madara/knowledge/KnowledgeBase.h"
+#include "madara/knowledge/BaseStreamer.h"
+
+/**
+ * @file CheckpointStreamer.h
+ * @author David Kyle <david.kyle@shield.ai>
+ *
+ * This file contains the CheckpointStream class which streams knowledge updates
+ * to serialized temporal knowledge (STK) checkpoints.
+ **/
+
+namespace madara { namespace knowledge {
+
+class MADARA_EXPORT CheckpointStreamer : public BaseStreamer
+{
+public:
+  CheckpointStreamer(
+      CheckpointSettings settings,
+      ThreadSafeContext &context,
+      double write_hertz = 10)
+    : settings_(std::move(settings)), context_(&context),
+      write_hertz_(write_hertz),
+      thread_(thread_main, (keep_running_.test_and_set(), this)) {}
+
+  CheckpointStreamer(
+      CheckpointSettings settings,
+      KnowledgeBase &kb,
+      double write_hertz = 10)
+    : CheckpointStreamer(std::move(settings), kb.get_context(), write_hertz) {}
+
+  void enqueue(std::string name, KnowledgeRecord record) override;
+
+  CheckpointStreamer(const CheckpointStreamer &) = delete;
+  CheckpointStreamer(CheckpointStreamer &&) = delete;
+  CheckpointStreamer &operator=(const CheckpointStreamer &) = delete;
+  CheckpointStreamer &operator=(CheckpointStreamer &&) = delete;
+
+  ~CheckpointStreamer() override;
+
+private:
+  static void thread_main(CheckpointStreamer *self);
+
+  void terminate()
+  {
+    keep_running_.clear();
+    if (thread_.joinable()) {
+      thread_.join();
+    }
+  }
+
+  CheckpointSettings settings_;
+  ThreadSafeContext *context_;
+
+  using pair_type = std::pair<std::string, KnowledgeRecord>;
+
+  std::vector<pair_type> in_buffer;
+  std::vector<pair_type> out_buffer;
+
+  double write_hertz_ = 10;
+
+  std::atomic_flag keep_running_;
+  std::thread thread_;
+};
+
+} } // namespace madara::knowledge
+
+#endif // MADARA_KNOWLEDGE_CHECKPOINT_STREAMER_H_

--- a/include/madara/knowledge/CheckpointStreamer.h
+++ b/include/madara/knowledge/CheckpointStreamer.h
@@ -22,9 +22,24 @@
 
 namespace madara { namespace knowledge {
 
+/**
+ * Implementation of BaseStreamer which writes updates to a Madara checkpoint
+ * file. Updates are kept in an in-memory buffer, and written to disk at the
+ * hertz rate specified in the constructor.
+ **/
 class MADARA_EXPORT CheckpointStreamer : public BaseStreamer
 {
 public:
+  /**
+   * Constructor.
+   *
+   * @param settings the CheckpointSettings used in calls to
+   *   ThreadSafeContext::save_checkpoint. The variables_lister and
+   *   reset_checkpoint fields given are ignored.
+   * @param context ThreadSafeContext this object is attached to. This context
+   *   will be locked for a short time each period.
+   * @param write_hertz hertz rate for periodic write to disk.
+   **/
   CheckpointStreamer(
       CheckpointSettings settings,
       ThreadSafeContext &context,
@@ -33,14 +48,30 @@ public:
       write_hertz_(write_hertz),
       thread_(thread_main, (keep_running_.test_and_set(), this)) {}
 
+  /**
+   * Constructor.
+   *
+   * @param settings the CheckpointSettings used in calls to
+   *   ThreadSafeContext::save_checkpoint. The variables_lister and
+   *   reset_checkpoint fields given are ignored.
+   * @param kb KnoweldgeBase this object is attached to. This KnoweldgeBase
+   *   will be locked for a short time each period.
+   * @param write_hertz hertz rate for periodic write to disk.
+   **/
   CheckpointStreamer(
       CheckpointSettings settings,
       KnowledgeBase &kb,
       double write_hertz = 10)
     : CheckpointStreamer(std::move(settings), kb.get_context(), write_hertz) {}
 
+  /**
+   * Implementation of BaseStreamer::enqueue, which stores the given parameters
+   * in an in-memory buffer, for later write to disk.
+   **/
   void enqueue(std::string name, KnowledgeRecord record) override;
 
+  // This object spawns a thread which holds a pointer back to this object,
+  // so it cannot be safely copied or moved.
   CheckpointStreamer(const CheckpointStreamer &) = delete;
   CheckpointStreamer(CheckpointStreamer &&) = delete;
   CheckpointStreamer &operator=(const CheckpointStreamer &) = delete;

--- a/include/madara/knowledge/ContextGuard.h
+++ b/include/madara/knowledge/ContextGuard.h
@@ -29,7 +29,7 @@ namespace madara
        * Arguments past first forwarded to underlying guard type
        **/
       template<typename... Args>
-      ContextGuard (KnowledgeBase & knowledge, Args&&... args);
+      ContextGuard (const KnowledgeBase & knowledge, Args&&... args);
 
       /**
        * Constructor
@@ -37,10 +37,10 @@ namespace madara
        * Arguments past first forwarded to underlying guard type
        **/
       template<typename... Args>
-      ContextGuard (ThreadSafeContext & context, Args&&... args);
+      ContextGuard (const ThreadSafeContext & context, Args&&... args);
 
     private:
-      std::lock_guard<ThreadSafeContext> guard_;
+      std::lock_guard<const ThreadSafeContext> guard_;
     };
 
   }

--- a/include/madara/knowledge/ContextGuard.inl
+++ b/include/madara/knowledge/ContextGuard.inl
@@ -4,14 +4,14 @@ namespace madara { namespace knowledge {
 
 template<typename... Args>
 inline ContextGuard::ContextGuard (
-  KnowledgeBase & knowledge, Args&&... args)
+  const KnowledgeBase & knowledge, Args&&... args)
   : guard_ (knowledge.get_context (), std::forward<Args>(args)...)
 {
 }
 
 template<typename... Args>
 inline ContextGuard::ContextGuard (
-  ThreadSafeContext & context, Args&&... args)
+  const ThreadSafeContext & context, Args&&... args)
   : guard_ (context, std::forward<Args>(args)...)
 {
 }

--- a/include/madara/knowledge/KnowledgeBase.h
+++ b/include/madara/knowledge/KnowledgeBase.h
@@ -1395,6 +1395,14 @@ namespace madara
       ThreadSafeContext & get_context (void);
 
       /**
+       * Returns the ThreadSafeContext associated with this Knowledge
+       * Base. This is necessary for creating custom transports.
+       *
+       * @return             the context used by the knowledge base
+       **/
+      const ThreadSafeContext & get_context (void) const;
+
+      /**
       * Gets the log level
       * @return the maximum detail level to print
       **/
@@ -1582,6 +1590,27 @@ namespace madara
 
       int64_t save_checkpoint (
         CheckpointSettings & settings) const;
+
+      /**
+       * Attach a streaming provider object, inherited from BaseStreamer,
+       * such as CheckpointStreamer. Once attached, all updates to records
+       * in this ThreadSafeContext will be provided to the streamer. May
+       * pass nullptr to stop streaming.
+       *
+       * @param streamer the new streamer to attach
+       * @return the old streamer, or nullptr if there wasn't any.
+       **/
+      std::unique_ptr<BaseStreamer> attach_streamer (
+        std::unique_ptr<BaseStreamer> streamer)
+      {
+        if (impl_) {
+          return impl_->attach_streamer(std::move(streamer));
+        } else {
+          return context_->attach_streamer(std::move(streamer));
+        }
+        throw_null_context();
+      }
+
 
       /**
        * Loads the context from a file

--- a/include/madara/knowledge/KnowledgeBase.inl
+++ b/include/madara/knowledge/KnowledgeBase.inl
@@ -1587,6 +1587,23 @@ KnowledgeBase::get_context (void)
   return *result;
 }
 
+inline const ThreadSafeContext &
+KnowledgeBase::get_context (void) const
+{
+  ThreadSafeContext * result = 0;
+
+  if (context_)
+  {
+    result = context_;
+  }
+  else if (impl_.get ())
+  {
+    result = &(impl_->get_context ());
+  }
+
+  return *result;
+}
+
 inline void
 KnowledgeBase::clear_modifieds (void)
 {

--- a/include/madara/knowledge/KnowledgeBaseImpl.h
+++ b/include/madara/knowledge/KnowledgeBaseImpl.h
@@ -1071,6 +1071,83 @@ namespace madara
       std::string setup_unique_hostport (std::string host = "");
 
     private:
+      struct ModifiedsSender
+      {
+        KnowledgeBaseImpl *self;
+        const char *func;
+        const EvalSettings *settings;
+
+        ~ModifiedsSender() { self->send_modifieds(func, *settings); }
+      };
+
+    public:
+      template<typename Callable>
+      auto invoke(const std::string &key,
+          Callable &&callable,
+          const EvalSettings &settings = EvalSettings())
+        -> decltype(invoke_(std::forward<Callable>(callable),
+             std::declval<KnowledgeRecord &>()))
+      {
+        ModifiedsSender sender = {this, "KnowledgeBase::invoke", &settings};
+        return map_.invoke(key, std::forward<Callable>(callable), settings);
+      }
+
+      template<typename Callable>
+      auto invoke(const VariableReference &key,
+          Callable &&callable,
+          const EvalSettings &settings = EvalSettings())
+        -> decltype(invoke_(std::forward<Callable>(callable),
+             std::declval<KnowledgeRecord &>()))
+      {
+        ModifiedsSender sender = {this, "KnowledgeBase::invoke", &settings};
+        return map_.invoke(key, std::forward<Callable>(callable), settings);
+      }
+
+      template<typename Callable>
+      auto invoke(const std::string &key,
+          Callable &&callable,
+          const KnowledgeReferenceSettings &settings =
+            KnowledgeReferenceSettings())
+        const -> decltype(invoke_(std::forward<Callable>(callable),
+             std::declval<KnowledgeRecord &>()))
+      {
+        return map_.invoke(key, std::forward<Callable>(callable), settings);
+      }
+
+      template<typename Callable>
+      auto invoke(const VariableReference &key,
+          Callable &&callable,
+          const KnowledgeReferenceSettings &settings =
+            KnowledgeReferenceSettings())
+        const -> decltype(invoke_(std::forward<Callable>(callable),
+             std::declval<KnowledgeRecord &>()))
+      {
+        return map_.invoke(key, std::forward<Callable>(callable), settings);
+      }
+
+      template<typename Callable>
+      auto cinvoke(const std::string &key,
+          Callable &&callable,
+          const KnowledgeReferenceSettings &settings =
+            KnowledgeReferenceSettings())
+        const -> decltype(invoke_(std::forward<Callable>(callable),
+             std::declval<KnowledgeRecord &>()))
+      {
+        return map_.cinvoke(key, std::forward<Callable>(callable), settings);
+      }
+
+      template<typename Callable>
+      auto cinvoke(const VariableReference &key,
+          Callable &&callable,
+          const KnowledgeReferenceSettings &settings =
+            KnowledgeReferenceSettings())
+        const -> decltype(invoke_(std::forward<Callable>(callable),
+             std::declval<KnowledgeRecord &>()))
+      {
+        return map_.cinvoke(key, std::forward<Callable>(callable), settings);
+      }
+
+    private:
       ThreadSafeContext                 map_;
       std::string                         id_;
       transport::QoSTransportSettings   settings_;

--- a/include/madara/knowledge/KnowledgeBaseImpl.h
+++ b/include/madara/knowledge/KnowledgeBaseImpl.h
@@ -948,6 +948,21 @@ namespace madara
         CheckpointSettings & settings) const;
 
       /**
+       * Attach a streaming provider object, inherited from BaseStreamer,
+       * such as CheckpointStreamer. Once attached, all updates to records
+       * in this ThreadSafeContext will be provided to the streamer. May
+       * pass nullptr to stop streaming.
+       *
+       * @param streamer the new streamer to attach
+       * @return the old streamer, or nullptr if there wasn't any.
+       **/
+      std::unique_ptr<BaseStreamer> attach_streamer (
+        std::unique_ptr<BaseStreamer> streamer)
+      {
+        return map_.attach_streamer(std::move(streamer));
+      }
+
+      /**
        * Loads the context from a file
        * @param   filename    name of the file to open
        * @param   use_id      if true, sets the unique identifier to the

--- a/include/madara/knowledge/KnowledgeCast.h
+++ b/include/madara/knowledge/KnowledgeCast.h
@@ -456,6 +456,15 @@ inline auto knowledge_cast(const T &in) ->
   return KnowledgeRecord{tags::binary, std::begin(in), std::end(in)};
 }
 
+template<typename T>
+inline auto knowledge_cast(const KnowledgeRecord& in, T&& out) ->
+  decltype(*out = knowledge_cast(
+        type<typename decay_<T>::container_type::value_type>{}, in))
+{
+  return (*out = knowledge_cast(
+        type<typename decay_<T>::container_type::value_type>{}, in));
+}
+
 /// Identity NOP
 inline KnowledgeRecord &knowledge_cast(KnowledgeRecord &in)
 {
@@ -702,7 +711,7 @@ size_t KnowledgeRecord::get_history_range(
     OutputIterator out, size_t index, size_t count) const
 {
   return for_history_range([&out](const KnowledgeRecord &rec) {
-      *out = knowledge_cast(rec);
+      knowledge_cast(rec, *out);
       ++out;
     }, index, count);
 }

--- a/include/madara/knowledge/KnowledgeCast.h
+++ b/include/madara/knowledge/KnowledgeCast.h
@@ -468,6 +468,13 @@ inline const KnowledgeRecord &knowledge_cast(const KnowledgeRecord &in)
   return in;
 }
 
+/// Identity NOP
+inline const KnowledgeRecord &knowledge_cast(
+    const KnowledgeRecord &in, KnowledgeRecord &out)
+{
+  return out = in;
+}
+
 #endif // !DOXYGEN
 
 /// Generates comparison operators for KnowledgeRecords, in combination with
@@ -688,6 +695,16 @@ BasicAny<Impl, ValImpl, RefImpl, CRefImpl>::from_record(
         "support to_record");
   }
   this->handler_->from_record(rec, this->data_);
+}
+
+template<typename OutputIterator>
+size_t KnowledgeRecord::get_history_range(
+    OutputIterator out, size_t index, size_t count) const
+{
+  return for_history_range([&out](const KnowledgeRecord &rec) {
+      *out = knowledge_cast(rec);
+      ++out;
+    }, index, count);
 }
 
 }

--- a/include/madara/knowledge/KnowledgeRecord.cpp
+++ b/include/madara/knowledge/KnowledgeRecord.cpp
@@ -138,7 +138,7 @@ KnowledgeRecord::to_file (const std::string & filename) const
   }
   else if (has_history ())
   {
-    return buf_->back ().to_file (filename);
+    return ref_newest ().to_file (filename);
   }
   else
   {
@@ -160,7 +160,7 @@ KnowledgeRecord::to_double (void) const
   else if (type_ == DOUBLE_ARRAY)
     value = double_array_->size () == 0 ? 0 : double_array_->at(0);
   else if (has_history())
-    return buf_->back ().to_double ();
+    return ref_newest ().to_double ();
   else if (type_ != EMPTY)
   {
     std::stringstream buffer;
@@ -189,7 +189,7 @@ KnowledgeRecord::to_integer (void) const
   else if (type_ == INTEGER_ARRAY)
     value = int_array_->size () == 0 ? 0 : int_array_->at(0);
   else if (has_history())
-    return buf_->back ().to_integer ();
+    return ref_newest ().to_integer ();
   else if (type_ != EMPTY)
   {
     std::stringstream buffer;
@@ -218,7 +218,7 @@ KnowledgeRecord::to_integers (void) const
   }
 
   if (has_history()) {
-    return buf_->back ().to_integers ();
+    return ref_newest ().to_integers ();
   }
 
   unsigned int size = (unsigned int)this->size ();
@@ -272,7 +272,7 @@ KnowledgeRecord::to_doubles (void) const
   }
 
   if (has_history()) {
-    return buf_->back ().to_doubles ();
+    return ref_newest ().to_doubles ();
   }
 
   unsigned int size = (unsigned int)this->size ();
@@ -323,7 +323,7 @@ KnowledgeRecord::to_string (const std::string & delimiter) const
   }
 
   if (has_history()) {
-    return buf_->back ().to_string ();
+    return ref_newest ().to_string ();
   }
 
   if (type_ == ANY) {
@@ -481,7 +481,7 @@ KnowledgeRecord::to_unmanaged_buffer (size_t & size) const
     buffer = new char [size];
     memcpy (buffer, &(*double_array_)[0], size);
   } else if (has_history ()) {
-    return buf_->back ().to_unmanaged_buffer (size);
+    return ref_newest ().to_unmanaged_buffer (size);
   } else {
     buffer = nullptr;
     size = 0;
@@ -574,11 +574,11 @@ KnowledgeRecord::operator< (
   const knowledge::KnowledgeRecord & rhs) const
 {
   if (has_history ()) {
-    return buf_->back ().operator< (rhs);
+    return ref_newest ().operator< (rhs);
   }
 
   if (rhs.has_history ()) {
-    return operator< (rhs.buf_->back ());
+    return operator< (rhs.ref_newest ());
   }
 
   Integer result (0);
@@ -668,11 +668,11 @@ KnowledgeRecord::operator<= (
   const knowledge::KnowledgeRecord & rhs) const
 {
   if (has_history ()) {
-    return buf_->back ().operator<= (rhs);
+    return ref_newest ().operator<= (rhs);
   }
 
   if (rhs.has_history ()) {
-    return operator<= (rhs.buf_->back ());
+    return operator<= (rhs.ref_newest ());
   }
 
   Integer result (0);
@@ -762,11 +762,11 @@ KnowledgeRecord::operator== (
   const knowledge::KnowledgeRecord & rhs) const
 {
   if (has_history ()) {
-    return buf_->back ().operator== (rhs);
+    return ref_newest ().operator== (rhs);
   }
 
   if (rhs.has_history ()) {
-    return operator== (rhs.buf_->back ());
+    return operator== (rhs.ref_newest ());
   }
 
   Integer result (0);
@@ -874,11 +874,11 @@ bool
 KnowledgeRecord::operator> (const knowledge::KnowledgeRecord & rhs) const
 {
   if (has_history ()) {
-    return buf_->back ().operator> (rhs);
+    return ref_newest ().operator> (rhs);
   }
 
   if (rhs.has_history ()) {
-    return operator> (rhs.buf_->back ());
+    return operator> (rhs.ref_newest ());
   }
 
   Integer result (0);
@@ -969,11 +969,11 @@ bool
 KnowledgeRecord::operator>= (const knowledge::KnowledgeRecord & rhs) const
 {
   if (has_history ()) {
-    return buf_->back ().operator>= (rhs);
+    return ref_newest ().operator>= (rhs);
   }
 
   if (rhs.has_history ()) {
-    return operator>= (rhs.buf_->back ());
+    return operator>= (rhs.ref_newest ());
   }
 
   Integer result (0);
@@ -1078,7 +1078,7 @@ KnowledgeRecord::retrieve_index (size_t index) const
   }
   else if (has_history ())
   {
-    return buf_->back ().retrieve_index (index);
+    return ref_newest ().retrieve_index (index);
   }
 
   return ret_value;

--- a/include/madara/knowledge/KnowledgeRecord.cpp
+++ b/include/madara/knowledge/KnowledgeRecord.cpp
@@ -588,13 +588,13 @@ KnowledgeRecord::operator< (
   {
     Integer lhs = this->to_integer ();
 
-    if (rhs.is_double_type (type_) || rhs.is_string_type (type_))
+    if (is_double_type (rhs.type_) || is_string_type (rhs.type_))
     {
       double other = rhs.to_double ();
 
       result = lhs < other;
     }
-    else if (rhs.is_integer_type (type_))
+    else if (is_integer_type (rhs.type_))
     {
       Integer other = rhs.to_integer ();
 
@@ -606,7 +606,7 @@ KnowledgeRecord::operator< (
   else if (is_string_type (type_))
   {
     // string to string comparison
-    if      (rhs.is_string_type (type_))
+    if      (is_string_type (rhs.type_))
     {
       result =
         strncmp (str_value_->c_str (), rhs.str_value_->c_str (), 
@@ -614,7 +614,7 @@ KnowledgeRecord::operator< (
     }
 
     // string to double comparison
-    else if (rhs.is_double_type (type_))
+    else if (is_double_type (rhs.type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -625,7 +625,7 @@ KnowledgeRecord::operator< (
     }
 
     // default is string to integer comparison
-    else if (rhs.is_integer_type (type_))
+    else if (is_integer_type (rhs.type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -642,7 +642,7 @@ KnowledgeRecord::operator< (
     double lhs = to_double ();
 
     // string to string comparison
-    if      (rhs.is_string_type (type_) || rhs.is_double_type (type_))
+    if      (is_string_type (rhs.type_) || is_double_type (rhs.type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -653,7 +653,7 @@ KnowledgeRecord::operator< (
     }
 
     // default is string to integer comparison
-    else if (rhs.is_integer_type (type_))
+    else if (is_integer_type (rhs.type_))
     {
       Integer other = rhs.to_integer ();
       result = lhs < other;
@@ -682,13 +682,13 @@ KnowledgeRecord::operator<= (
   {
     Integer lhs = this->to_integer ();
 
-    if (rhs.is_double_type (type_) || rhs.is_string_type (type_))
+    if (is_double_type (rhs.type_) || is_string_type (rhs.type_))
     {
       double other = rhs.to_double ();
 
       result = lhs <= other;
     }
-    else if (rhs.is_integer_type (type_))
+    else if (is_integer_type (rhs.type_))
     {
       Integer other = rhs.to_integer ();
 
@@ -700,7 +700,7 @@ KnowledgeRecord::operator<= (
   else if (is_string_type (type_))
   {
     // string to string comparison
-    if      (rhs.is_string_type (type_))
+    if      (is_string_type (rhs.type_))
     {
       result = 
         strncmp (str_value_->c_str (), rhs.str_value_->c_str (), 
@@ -708,7 +708,7 @@ KnowledgeRecord::operator<= (
     }
 
     // string to double comparison
-    else if (rhs.is_double_type (type_))
+    else if (is_double_type (rhs.type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -719,7 +719,7 @@ KnowledgeRecord::operator<= (
     }
 
     // default is string to integer comparison
-    else if (rhs.is_integer_type (type_))
+    else if (is_integer_type (rhs.type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -736,7 +736,7 @@ KnowledgeRecord::operator<= (
     double lhs = to_double ();
 
     // string to string comparison
-    if      (rhs.is_string_type (type_) || rhs.is_double_type (type_))
+    if      (is_string_type (rhs.type_) || is_double_type (rhs.type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -747,7 +747,7 @@ KnowledgeRecord::operator<= (
     }
 
     // default is string to integer comparison
-    else if (rhs.is_integer_type (type_))
+    else if (is_integer_type (rhs.type_))
     {
       Integer other = rhs.to_integer ();
       result = lhs <= other;
@@ -783,15 +783,15 @@ KnowledgeRecord::operator== (
   // if the left hand side is an integer
   else if (is_integer_type (type_))
   {
-    if (rhs.is_double_type (type_))
+    if (is_double_type (rhs.type_))
     {
       result = to_double () == rhs.to_double ();
     }
-    else if (rhs.is_integer_type (type_))
+    else if (is_integer_type (rhs.type_))
     {
       result = to_integer () == rhs.to_integer ();
     }
-    else if (rhs.is_string_type (type_))
+    else if (is_string_type (rhs.type_))
     {
       if (rhs.size () > 0 && rhs.str_value_->at (0) >= '0' &&
         rhs.str_value_->at (0) <= '9')
@@ -806,7 +806,7 @@ KnowledgeRecord::operator== (
   else if (is_string_type (type_))
   {
     // string to string comparison
-    if      (rhs.is_string_type (type_))
+    if      (is_string_type (rhs.type_))
     {
       result = 
         strncmp (str_value_->c_str (), rhs.str_value_->c_str (), 
@@ -814,7 +814,7 @@ KnowledgeRecord::operator== (
     }
 
     // string to double comparison
-    else if (rhs.is_double_type (type_))
+    else if (is_double_type (rhs.type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -828,7 +828,7 @@ KnowledgeRecord::operator== (
     }
 
     // default is string to integer comparison
-    else if (rhs.is_integer_type (type_))
+    else if (is_integer_type (rhs.type_))
     {
       if (size () > 0 && this->str_value_->at (0) >= '0' &&
         this->str_value_->at (0) <= '9')
@@ -848,7 +848,7 @@ KnowledgeRecord::operator== (
     double lhs = to_double ();
 
     // string to string comparison
-    if      (rhs.is_string_type (type_) || rhs.is_double_type (type_))
+    if      (is_string_type (rhs.type_) || is_double_type (rhs.type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -859,7 +859,7 @@ KnowledgeRecord::operator== (
     }
 
     // default is string to integer comparison
-    else if (rhs.is_integer_type (type_))
+    else if (is_integer_type (rhs.type_))
     {
       Integer other = rhs.to_integer ();
 
@@ -888,13 +888,13 @@ KnowledgeRecord::operator> (const knowledge::KnowledgeRecord & rhs) const
   {
     Integer lhs = this->to_integer ();
 
-    if (rhs.is_double_type (type_) || rhs.is_string_type (type_))
+    if (is_double_type (rhs.type_) || is_string_type (rhs.type_))
     {
       double other = rhs.to_double ();
 
       result = lhs > other;
     }
-    else if (rhs.is_integer_type (type_))
+    else if (is_integer_type (rhs.type_))
     {
       Integer other = rhs.to_integer ();
 
@@ -907,7 +907,7 @@ KnowledgeRecord::operator> (const knowledge::KnowledgeRecord & rhs) const
   else if (is_string_type (type_))
   {
     // string to string comparison
-    if      (rhs.is_string_type (type_))
+    if      (is_string_type (rhs.type_))
     {
       result = 
         strncmp (str_value_->c_str (), rhs.str_value_->c_str (), 
@@ -915,7 +915,7 @@ KnowledgeRecord::operator> (const knowledge::KnowledgeRecord & rhs) const
     }
 
     // string to double comparison
-    else if (rhs.is_double_type (type_))
+    else if (is_double_type (rhs.type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -926,7 +926,7 @@ KnowledgeRecord::operator> (const knowledge::KnowledgeRecord & rhs) const
     }
 
     // default is string to integer comparison
-    else if (rhs.is_integer_type (type_))
+    else if (is_integer_type (rhs.type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -943,7 +943,7 @@ KnowledgeRecord::operator> (const knowledge::KnowledgeRecord & rhs) const
     double lhs = to_double ();
 
     // string to string comparison
-    if      (rhs.is_string_type (type_) || rhs.is_double_type (type_))
+    if      (is_string_type (rhs.type_) || is_double_type (rhs.type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -954,7 +954,7 @@ KnowledgeRecord::operator> (const knowledge::KnowledgeRecord & rhs) const
     }
 
     // default is string to integer comparison
-    else if (rhs.is_integer_type (type_))
+    else if (is_integer_type (rhs.type_))
     {
       Integer other = rhs.to_integer ();
 
@@ -983,13 +983,13 @@ KnowledgeRecord::operator>= (const knowledge::KnowledgeRecord & rhs) const
   {
     Integer lhs = this->to_integer ();
 
-    if (rhs.is_double_type (type_) || rhs.is_string_type (type_))
+    if (is_double_type (rhs.type_) || is_string_type (rhs.type_))
     {
       double other = rhs.to_double ();
 
       result = lhs >= other;
     }
-    else if (rhs.is_integer_type (type_))
+    else if (is_integer_type (rhs.type_))
     {
       Integer other = rhs.to_integer ();
 
@@ -1002,7 +1002,7 @@ KnowledgeRecord::operator>= (const knowledge::KnowledgeRecord & rhs) const
   else if (is_string_type (type_))
   {
     // string to string comparison
-    if      (rhs.is_string_type (type_))
+    if      (is_string_type (rhs.type_))
     {
       result =
         strncmp (str_value_->c_str (), rhs.str_value_->c_str (), 
@@ -1010,7 +1010,7 @@ KnowledgeRecord::operator>= (const knowledge::KnowledgeRecord & rhs) const
     }
 
     // string to double comparison
-    else if (rhs.is_double_type (type_))
+    else if (is_double_type (rhs.type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -1021,7 +1021,7 @@ KnowledgeRecord::operator>= (const knowledge::KnowledgeRecord & rhs) const
     }
 
     // default is string to integer comparison
-    else if (rhs.is_integer_type (type_))
+    else if (is_integer_type (rhs.type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -1038,7 +1038,7 @@ KnowledgeRecord::operator>= (const knowledge::KnowledgeRecord & rhs) const
     double lhs = to_double ();
 
     // string to string comparison
-    if      (rhs.is_string_type (type_) || rhs.is_double_type (type_))
+    if      (is_string_type (rhs.type_) || is_double_type (rhs.type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -1049,7 +1049,7 @@ KnowledgeRecord::operator>= (const knowledge::KnowledgeRecord & rhs) const
     }
 
     // default is string to integer comparison
-    else if (rhs.is_integer_type (type_))
+    else if (is_integer_type (rhs.type_))
     {
       Integer other = rhs.to_integer ();
 

--- a/include/madara/knowledge/KnowledgeRecord.cpp
+++ b/include/madara/knowledge/KnowledgeRecord.cpp
@@ -64,6 +64,13 @@ KnowledgeRecord::read_file (
   size_t size;
   bool add_zero_char = false;
 
+  if (has_history ()) {
+    KnowledgeRecord tmp;
+    int ret = tmp.read_file (filename, read_as_type);
+    set_value (std::move(tmp));
+    return ret;
+  }
+
   // clear the old value
   clear_value ();
 
@@ -119,15 +126,19 @@ KnowledgeRecord::read_file (
 ssize_t
 KnowledgeRecord::to_file (const std::string & filename) const
 {
-  if (is_string_type ())
+  if (is_string_type (type_))
   {
     return madara::utility::write_file (filename,
       (void *)str_value_->c_str (), str_value_->size ());
   }
-  else if (is_binary_file_type ())
+  else if (is_binary_file_type (type_))
   {
     return madara::utility::write_file (filename,
       (void *)&file_value_->at(0), file_value_->size ());
+  }
+  else if (has_history ())
+  {
+    return buf_->back ().to_file (filename);
   }
   else
   {
@@ -148,6 +159,8 @@ KnowledgeRecord::to_double (void) const
     value = double_value_;
   else if (type_ == DOUBLE_ARRAY)
     value = double_array_->size () == 0 ? 0 : double_array_->at(0);
+  else if (has_history())
+    return buf_->back ().to_double ();
   else if (type_ != EMPTY)
   {
     std::stringstream buffer;
@@ -157,7 +170,7 @@ KnowledgeRecord::to_double (void) const
       buffer << int_value_;
     else if (type_ == INTEGER_ARRAY)
       buffer << (int_array_->size () == 0 ? 0 : int_array_->at(0));
-    else if (is_string_type ())
+    else if (is_string_type (type_))
       buffer << str_value_->c_str ();
 
     buffer >> value;
@@ -175,6 +188,8 @@ KnowledgeRecord::to_integer (void) const
     value = int_value_;
   else if (type_ == INTEGER_ARRAY)
     value = int_array_->size () == 0 ? 0 : int_array_->at(0);
+  else if (has_history())
+    return buf_->back ().to_integer ();
   else if (type_ != EMPTY)
   {
     std::stringstream buffer;
@@ -184,7 +199,7 @@ KnowledgeRecord::to_integer (void) const
       buffer << double_value_;
     else if (type_ == DOUBLE_ARRAY)
       buffer << (double_array_->size () == 0 ? 0 : double_array_->at(0));
-    else if (is_string_type ())
+    else if (is_string_type (type_))
       buffer << str_value_->c_str();
 
     buffer >> value;
@@ -200,6 +215,10 @@ KnowledgeRecord::to_integers (void) const
 
   if (type_ == EMPTY) {
     return integers;
+  }
+
+  if (has_history()) {
+    return buf_->back ().to_integers ();
   }
 
   unsigned int size = (unsigned int)this->size ();
@@ -225,14 +244,14 @@ KnowledgeRecord::to_integers (void) const
     for (unsigned int i = 0; i < size; ++i)
       integers[i] = Integer (ptr_temp[i]);
   }
-  else if (is_string_type ())
+  else if (is_string_type (type_))
   {
     const char * ptr_temp = str_value_->c_str ();
 
     for (unsigned int i = 0; i < size; ++i)
       integers[i] = Integer (ptr_temp[i]);
   }
-  else if (is_binary_file_type ())
+  else if (is_binary_file_type (type_))
   {
     const unsigned char * ptr_temp = &(*file_value_)[0];
 
@@ -250,6 +269,10 @@ KnowledgeRecord::to_doubles (void) const
 
   if (type_ == EMPTY) {
     return doubles;
+  }
+
+  if (has_history()) {
+    return buf_->back ().to_doubles ();
   }
 
   unsigned int size = (unsigned int)this->size ();
@@ -273,14 +296,14 @@ KnowledgeRecord::to_doubles (void) const
     for (unsigned int i = 0; i < size; ++i)
       doubles[i] = ptr_temp[i];
   }
-  else if (is_string_type ())
+  else if (is_string_type (type_))
   {
     const char * ptr_temp = str_value_->c_str ();
 
     for (unsigned int i = 0; i < size; ++i)
       doubles[i] = double (ptr_temp[i]);
   }
-  else if (is_binary_file_type ())
+  else if (is_binary_file_type (type_))
   {
     const unsigned char * ptr_temp = &(*file_value_)[0];
 
@@ -299,11 +322,15 @@ KnowledgeRecord::to_string (const std::string & delimiter) const
     return "";
   }
 
+  if (has_history()) {
+    return buf_->back ().to_string ();
+  }
+
   if (type_ == ANY) {
     return any_value_->to_json();
   }
 
-  if (!is_string_type ())
+  if (!is_string_type (type_))
   {
     madara_logger_ptr_log (logger_, logger::LOG_DETAILED, "KnowledgeRecord::to_string:" \
       " type_ is %d\n", type_);
@@ -401,7 +428,7 @@ KnowledgeRecord::to_string (const std::string & delimiter) const
       for (uint32_t i = 1; i < size; ++i, ++ptr_temp)
         buffer << delimiter << *ptr_temp; 
     }
-    else if (is_binary_file_type ())
+    else if (is_binary_file_type (type_))
     {
       buffer << "binary:size=";
       buffer << size (); 
@@ -418,13 +445,13 @@ KnowledgeRecord::to_unmanaged_buffer (size_t & size) const
 {
   char * buffer;
 
-  if (is_string_type ())
+  if (is_string_type (type_))
   {
     size = str_value_->size ();
     buffer = new char [size];
     memcpy (buffer, str_value_->c_str (), size);
   }
-  else if (is_binary_file_type ())
+  else if (is_binary_file_type (type_))
   {
     size = file_value_-> size();
     buffer = new char [size];
@@ -453,6 +480,8 @@ KnowledgeRecord::to_unmanaged_buffer (size_t & size) const
     size = sizeof(double) * double_array_->size () ;
     buffer = new char [size];
     memcpy (buffer, &(*double_array_)[0], size);
+  } else if (has_history ()) {
+    return buf_->back ().to_unmanaged_buffer (size);
   } else {
     buffer = nullptr;
     size = 0;
@@ -465,9 +494,13 @@ KnowledgeRecord::to_unmanaged_buffer (size_t & size) const
 KnowledgeRecord
 KnowledgeRecord::fragment (unsigned int first, unsigned int last)
 {
+  if (has_history ()) {
+    return fragment (first, last);
+  }
+
   knowledge::KnowledgeRecord ret;
 
-  if (is_string_type ())
+  if (is_string_type (type_))
   {
     unsigned int size = (unsigned int)str_value_->size ();
 
@@ -482,7 +515,7 @@ KnowledgeRecord::fragment (unsigned int first, unsigned int last)
 
     ret.set_value (new_buffer);
   }
-  else if (is_binary_file_type ())
+  else if (is_binary_file_type (type_))
   {
     unsigned int size = (unsigned int)file_value_->size ();
 
@@ -540,20 +573,28 @@ bool
 KnowledgeRecord::operator< (
   const knowledge::KnowledgeRecord & rhs) const
 {
+  if (has_history ()) {
+    return buf_->back ().operator< (rhs);
+  }
+
+  if (rhs.has_history ()) {
+    return operator< (rhs.buf_->back ());
+  }
+
   Integer result (0);
 
   // if the left hand side is an integer
-  if (is_integer_type ())
+  if (is_integer_type (type_))
   {
     Integer lhs = this->to_integer ();
 
-    if (rhs.is_double_type () || rhs.is_string_type ())
+    if (rhs.is_double_type (type_) || rhs.is_string_type (type_))
     {
       double other = rhs.to_double ();
 
       result = lhs < other;
     }
-    else if (rhs.is_integer_type ())
+    else if (rhs.is_integer_type (type_))
     {
       Integer other = rhs.to_integer ();
 
@@ -562,10 +603,10 @@ KnowledgeRecord::operator< (
   }
 
   // if the left hand side is a string
-  else if (is_string_type ())
+  else if (is_string_type (type_))
   {
     // string to string comparison
-    if      (rhs.is_string_type ())
+    if      (rhs.is_string_type (type_))
     {
       result =
         strncmp (str_value_->c_str (), rhs.str_value_->c_str (), 
@@ -573,7 +614,7 @@ KnowledgeRecord::operator< (
     }
 
     // string to double comparison
-    else if (rhs.is_double_type ())
+    else if (rhs.is_double_type (type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -584,7 +625,7 @@ KnowledgeRecord::operator< (
     }
 
     // default is string to integer comparison
-    else if (rhs.is_integer_type ())
+    else if (rhs.is_integer_type (type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -596,12 +637,12 @@ KnowledgeRecord::operator< (
   }
 
   // if the left hand side is a double
-  else if (is_double_type ())
+  else if (is_double_type (type_))
   {
     double lhs = to_double ();
 
     // string to string comparison
-    if      (rhs.is_string_type () || rhs.is_double_type ())
+    if      (rhs.is_string_type (type_) || rhs.is_double_type (type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -612,7 +653,7 @@ KnowledgeRecord::operator< (
     }
 
     // default is string to integer comparison
-    else if (rhs.is_integer_type ())
+    else if (rhs.is_integer_type (type_))
     {
       Integer other = rhs.to_integer ();
       result = lhs < other;
@@ -626,20 +667,28 @@ bool
 KnowledgeRecord::operator<= (
   const knowledge::KnowledgeRecord & rhs) const
 {
+  if (has_history ()) {
+    return buf_->back ().operator<= (rhs);
+  }
+
+  if (rhs.has_history ()) {
+    return operator<= (rhs.buf_->back ());
+  }
+
   Integer result (0);
 
   // if the left hand side is an integer
-  if (is_integer_type ())
+  if (is_integer_type (type_))
   {
     Integer lhs = this->to_integer ();
 
-    if (rhs.is_double_type () || rhs.is_string_type ())
+    if (rhs.is_double_type (type_) || rhs.is_string_type (type_))
     {
       double other = rhs.to_double ();
 
       result = lhs <= other;
     }
-    else if (rhs.is_integer_type ())
+    else if (rhs.is_integer_type (type_))
     {
       Integer other = rhs.to_integer ();
 
@@ -648,10 +697,10 @@ KnowledgeRecord::operator<= (
   }
 
   // if the left hand side is a string
-  else if (is_string_type ())
+  else if (is_string_type (type_))
   {
     // string to string comparison
-    if      (rhs.is_string_type ())
+    if      (rhs.is_string_type (type_))
     {
       result = 
         strncmp (str_value_->c_str (), rhs.str_value_->c_str (), 
@@ -659,7 +708,7 @@ KnowledgeRecord::operator<= (
     }
 
     // string to double comparison
-    else if (rhs.is_double_type ())
+    else if (rhs.is_double_type (type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -670,7 +719,7 @@ KnowledgeRecord::operator<= (
     }
 
     // default is string to integer comparison
-    else if (rhs.is_integer_type ())
+    else if (rhs.is_integer_type (type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -682,12 +731,12 @@ KnowledgeRecord::operator<= (
   }
 
   // if the left hand side is a double
-  else if (is_double_type ())
+  else if (is_double_type (type_))
   {
     double lhs = to_double ();
 
     // string to string comparison
-    if      (rhs.is_string_type () || rhs.is_double_type ())
+    if      (rhs.is_string_type (type_) || rhs.is_double_type (type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -698,7 +747,7 @@ KnowledgeRecord::operator<= (
     }
 
     // default is string to integer comparison
-    else if (rhs.is_integer_type ())
+    else if (rhs.is_integer_type (type_))
     {
       Integer other = rhs.to_integer ();
       result = lhs <= other;
@@ -712,6 +761,14 @@ bool
 KnowledgeRecord::operator== (
   const knowledge::KnowledgeRecord & rhs) const
 {
+  if (has_history ()) {
+    return buf_->back ().operator== (rhs);
+  }
+
+  if (rhs.has_history ()) {
+    return operator== (rhs.buf_->back ());
+  }
+
   Integer result (0);
 
   // if left hand side does 
@@ -724,17 +781,17 @@ KnowledgeRecord::operator== (
   }
 
   // if the left hand side is an integer
-  else if (is_integer_type ())
+  else if (is_integer_type (type_))
   {
-    if (rhs.is_double_type ())
+    if (rhs.is_double_type (type_))
     {
       result = to_double () == rhs.to_double ();
     }
-    else if (rhs.is_integer_type ())
+    else if (rhs.is_integer_type (type_))
     {
       result = to_integer () == rhs.to_integer ();
     }
-    else if (rhs.is_string_type ())
+    else if (rhs.is_string_type (type_))
     {
       if (rhs.size () > 0 && rhs.str_value_->at (0) >= '0' &&
         rhs.str_value_->at (0) <= '9')
@@ -746,10 +803,10 @@ KnowledgeRecord::operator== (
   }
 
   // if the left hand side is a string
-  else if (is_string_type ())
+  else if (is_string_type (type_))
   {
     // string to string comparison
-    if      (rhs.is_string_type ())
+    if      (rhs.is_string_type (type_))
     {
       result = 
         strncmp (str_value_->c_str (), rhs.str_value_->c_str (), 
@@ -757,7 +814,7 @@ KnowledgeRecord::operator== (
     }
 
     // string to double comparison
-    else if (rhs.is_double_type ())
+    else if (rhs.is_double_type (type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -771,7 +828,7 @@ KnowledgeRecord::operator== (
     }
 
     // default is string to integer comparison
-    else if (rhs.is_integer_type ())
+    else if (rhs.is_integer_type (type_))
     {
       if (size () > 0 && this->str_value_->at (0) >= '0' &&
         this->str_value_->at (0) <= '9')
@@ -786,12 +843,12 @@ KnowledgeRecord::operator== (
   }
 
   // if the left hand side is a double
-  else if (is_double_type ())
+  else if (is_double_type (type_))
   {
     double lhs = to_double ();
 
     // string to string comparison
-    if      (rhs.is_string_type () || rhs.is_double_type ())
+    if      (rhs.is_string_type (type_) || rhs.is_double_type (type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -802,7 +859,7 @@ KnowledgeRecord::operator== (
     }
 
     // default is string to integer comparison
-    else if (rhs.is_integer_type ())
+    else if (rhs.is_integer_type (type_))
     {
       Integer other = rhs.to_integer ();
 
@@ -816,20 +873,28 @@ KnowledgeRecord::operator== (
 bool
 KnowledgeRecord::operator> (const knowledge::KnowledgeRecord & rhs) const
 {
+  if (has_history ()) {
+    return buf_->back ().operator> (rhs);
+  }
+
+  if (rhs.has_history ()) {
+    return operator> (rhs.buf_->back ());
+  }
+
   Integer result (0);
 
   // if the left hand side is an integer
-  if (is_integer_type ())
+  if (is_integer_type (type_))
   {
     Integer lhs = this->to_integer ();
 
-    if (rhs.is_double_type () || rhs.is_string_type ())
+    if (rhs.is_double_type (type_) || rhs.is_string_type (type_))
     {
       double other = rhs.to_double ();
 
       result = lhs > other;
     }
-    else if (rhs.is_integer_type ())
+    else if (rhs.is_integer_type (type_))
     {
       Integer other = rhs.to_integer ();
 
@@ -839,10 +904,10 @@ KnowledgeRecord::operator> (const knowledge::KnowledgeRecord & rhs) const
 
 
   // if the left hand side is a string
-  else if (is_string_type ())
+  else if (is_string_type (type_))
   {
     // string to string comparison
-    if      (rhs.is_string_type ())
+    if      (rhs.is_string_type (type_))
     {
       result = 
         strncmp (str_value_->c_str (), rhs.str_value_->c_str (), 
@@ -850,7 +915,7 @@ KnowledgeRecord::operator> (const knowledge::KnowledgeRecord & rhs) const
     }
 
     // string to double comparison
-    else if (rhs.is_double_type ())
+    else if (rhs.is_double_type (type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -861,7 +926,7 @@ KnowledgeRecord::operator> (const knowledge::KnowledgeRecord & rhs) const
     }
 
     // default is string to integer comparison
-    else if (rhs.is_integer_type ())
+    else if (rhs.is_integer_type (type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -873,12 +938,12 @@ KnowledgeRecord::operator> (const knowledge::KnowledgeRecord & rhs) const
   }
 
   // if the left hand side is a double
-  else if (is_double_type ())
+  else if (is_double_type (type_))
   {
     double lhs = to_double ();
 
     // string to string comparison
-    if      (rhs.is_string_type () || rhs.is_double_type ())
+    if      (rhs.is_string_type (type_) || rhs.is_double_type (type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -889,7 +954,7 @@ KnowledgeRecord::operator> (const knowledge::KnowledgeRecord & rhs) const
     }
 
     // default is string to integer comparison
-    else if (rhs.is_integer_type ())
+    else if (rhs.is_integer_type (type_))
     {
       Integer other = rhs.to_integer ();
 
@@ -903,20 +968,28 @@ KnowledgeRecord::operator> (const knowledge::KnowledgeRecord & rhs) const
 bool
 KnowledgeRecord::operator>= (const knowledge::KnowledgeRecord & rhs) const
 {
+  if (has_history ()) {
+    return buf_->back ().operator>= (rhs);
+  }
+
+  if (rhs.has_history ()) {
+    return operator>= (rhs.buf_->back ());
+  }
+
   Integer result (0);
 
   // if the left hand side is an integer
-  if (is_integer_type ())
+  if (is_integer_type (type_))
   {
     Integer lhs = this->to_integer ();
 
-    if (rhs.is_double_type () || rhs.is_string_type ())
+    if (rhs.is_double_type (type_) || rhs.is_string_type (type_))
     {
       double other = rhs.to_double ();
 
       result = lhs >= other;
     }
-    else if (rhs.is_integer_type ())
+    else if (rhs.is_integer_type (type_))
     {
       Integer other = rhs.to_integer ();
 
@@ -926,10 +999,10 @@ KnowledgeRecord::operator>= (const knowledge::KnowledgeRecord & rhs) const
 
 
   // if the left hand side is a string
-  else if (is_string_type ())
+  else if (is_string_type (type_))
   {
     // string to string comparison
-    if      (rhs.is_string_type ())
+    if      (rhs.is_string_type (type_))
     {
       result =
         strncmp (str_value_->c_str (), rhs.str_value_->c_str (), 
@@ -937,7 +1010,7 @@ KnowledgeRecord::operator>= (const knowledge::KnowledgeRecord & rhs) const
     }
 
     // string to double comparison
-    else if (rhs.is_double_type ())
+    else if (rhs.is_double_type (type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -948,7 +1021,7 @@ KnowledgeRecord::operator>= (const knowledge::KnowledgeRecord & rhs) const
     }
 
     // default is string to integer comparison
-    else if (rhs.is_integer_type ())
+    else if (rhs.is_integer_type (type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -960,12 +1033,12 @@ KnowledgeRecord::operator>= (const knowledge::KnowledgeRecord & rhs) const
   }
 
   // if the left hand side is a double
-  else if (is_double_type ())
+  else if (is_double_type (type_))
   {
     double lhs = to_double ();
 
     // string to string comparison
-    if      (rhs.is_string_type () || rhs.is_double_type ())
+    if      (rhs.is_string_type (type_) || rhs.is_double_type (type_))
     {
       // when comparing strings to anything else, convert the
       // value into a double for maximum precision
@@ -976,7 +1049,7 @@ KnowledgeRecord::operator>= (const knowledge::KnowledgeRecord & rhs) const
     }
 
     // default is string to integer comparison
-    else if (rhs.is_integer_type ())
+    else if (rhs.is_integer_type (type_))
     {
       Integer other = rhs.to_integer ();
 
@@ -1003,6 +1076,10 @@ KnowledgeRecord::retrieve_index (size_t index) const
     if (index < size_t (double_array_-> size ()))
       ret_value.set_value (double_array_->at (index));
   }
+  else if (has_history ())
+  {
+    return buf_->back ().retrieve_index (index);
+  }
 
   return ret_value;
 }
@@ -1027,6 +1104,13 @@ KnowledgeRecord::dec_index (size_t index)
       int_array_->resize (index + 1);
     }
     return knowledge::KnowledgeRecord(--int_array_->at (index));
+  }
+  else if (has_history ())
+  {
+    KnowledgeRecord tmp = get_newest ();
+    tmp.dec_index (index);
+    set_value (tmp);
+    return tmp;
   }
   std::vector<Integer> tmp(index + 1);
   emplace_integers (std::move(tmp));
@@ -1054,6 +1138,13 @@ KnowledgeRecord::inc_index (size_t index)
     }
     return knowledge::KnowledgeRecord(++int_array_->at (index));
   }
+  else if (has_history ())
+  {
+    KnowledgeRecord tmp = get_newest ();
+    tmp.inc_index (index);
+    set_value (tmp);
+    return tmp;
+  }
   std::vector<Integer> tmp(index + 1);
   emplace_integers (std::move(tmp));
   return knowledge::KnowledgeRecord(++int_array_->at (index));
@@ -1062,6 +1153,13 @@ KnowledgeRecord::inc_index (size_t index)
 void
 KnowledgeRecord::resize (size_t new_size)
 {
+  if (has_history ()) {
+    KnowledgeRecord tmp = get_newest ();
+    tmp.resize (new_size);
+    set_value (std::move(tmp));
+    return;
+  }
+
   size_t cur_size = size ();
 
   if (cur_size == new_size) {
@@ -1172,24 +1270,28 @@ KnowledgeRecord::is_true (void) const
   madara_logger_ptr_log (logger_, logger::LOG_MAJOR, "KnowledgeRecord::apply:" \
     " checking if record is non-zero.\n");
 
-  if (is_integer_type ())
+  if (is_integer_type (type_))
     return to_integer () != 0;
-  else if (is_double_type ())
+  else if (is_double_type (type_))
   {
     double value = to_double ();
     return value < 0 || value > 0;
   }
-  else if (is_string_type ())
+  else if (is_string_type (type_))
   {
     return str_value_->size () >= 1;
   }
-  else if (is_binary_file_type ())
+  else if (is_binary_file_type (type_))
   {
     return file_value_->size () >= 1;
   }
-  else if (is_any_type ())
+  else if (is_any_type (type_))
   {
     return !any_value_->empty ();
+  }
+  else if (has_history ())
+  {
+    return ref_newest ().is_true();
   }
   else
   {

--- a/include/madara/knowledge/KnowledgeRecord.h
+++ b/include/madara/knowledge/KnowledgeRecord.h
@@ -1945,6 +1945,24 @@ namespace madara
         return ret;
       }
 
+      size_t get_history_newest_index() const
+      {
+        if (!has_history()) {
+          return 0;
+        }
+        return buf_->back_index();
+      }
+
+      size_t get_history_oldest_index() const
+      {
+        if (!has_history()) {
+          return 0;
+        }
+        return buf_->front_index();
+      }
+
+      std::shared_ptr<CircBuf> share_circular_buffer() const;
+
       /**
        * Set metadata of this record equal to that of new_value, but doesn't
        * change value. Metadata is toi, clock, quality, write_quality, and

--- a/include/madara/knowledge/KnowledgeRecord.inl
+++ b/include/madara/knowledge/KnowledgeRecord.inl
@@ -1655,6 +1655,16 @@ KnowledgeRecord::share_any() const
   return nullptr;
 }
 
+inline std::shared_ptr<KnowledgeRecord::CircBuf>
+KnowledgeRecord::share_circular_buffer() const
+{
+  if (!has_history()) {
+    return nullptr;
+  }
+  shared_ = SHARED;
+  return buf_;
+}
+
 inline
 KnowledgeRecord::operator bool (void) const
 {

--- a/include/madara/knowledge/KnowledgeRecord.inl
+++ b/include/madara/knowledge/KnowledgeRecord.inl
@@ -677,16 +677,16 @@ KnowledgeRecord::size (void) const
   return 1;
 }
 
-inline int32_t
+inline uint32_t
 KnowledgeRecord::type (void) const
 {
   return type_;
 }
 
 inline bool
-KnowledgeRecord::set_type (int32_t type)
+KnowledgeRecord::set_type (uint32_t type)
 {
-  if ((uint32_t)type == type_ ||
+  if (type == type_ ||
       (is_string_type() && is_string_type(type)) ||
       (is_binary_file_type() && is_binary_file_type(type))
   ) {

--- a/include/madara/knowledge/KnowledgeRecord.inl
+++ b/include/madara/knowledge/KnowledgeRecord.inl
@@ -187,9 +187,9 @@ inline KnowledgeRecord::KnowledgeRecord (
     double_value_ = rhs.double_value_;
   else if (rhs.type_ == DOUBLE_ARRAY)
     new (&double_array_) std::shared_ptr<std::vector<double>>(rhs.double_array_);
-  else if (rhs.is_string_type (type_))
+  else if (is_string_type (rhs.type_))
     new (&str_value_) std::shared_ptr<std::string>(rhs.str_value_);
-  else if (rhs.is_binary_file_type (type_))
+  else if (is_binary_file_type (rhs.type_))
     new (&file_value_) std::shared_ptr<std::vector<unsigned char>>(rhs.file_value_);
   else if (rhs.type_ == ANY)
     new (&any_value_) std::shared_ptr<ConstAny>(rhs.any_value_);
@@ -218,9 +218,9 @@ inline KnowledgeRecord::KnowledgeRecord (
     double_value_ = rhs.double_value_;
   else if (rhs.type_ == DOUBLE_ARRAY)
     new (&double_array_) std::shared_ptr<std::vector<double>>(std::move(rhs.double_array_));
-  else if (rhs.is_string_type (type_))
+  else if (is_string_type (rhs.type_))
     new (&str_value_) std::shared_ptr<std::string>(std::move(rhs.str_value_));
-  else if (rhs.is_binary_file_type (type_))
+  else if (is_binary_file_type (rhs.type_))
     new (&file_value_) std::shared_ptr<std::vector<unsigned char>>(std::move(rhs.file_value_));
   else if (rhs.type_ == ANY)
     new (&any_value_) std::shared_ptr<ConstAny>(std::move(rhs.any_value_));
@@ -327,9 +327,9 @@ KnowledgeRecord::overwrite (const KnowledgeRecord &rhs)
     double_value_ = rhs.double_value_;
   else if (rhs.type_ == DOUBLE_ARRAY)
     new (&double_array_) std::shared_ptr<std::vector<double>>(rhs.double_array_);
-  else if (rhs.is_string_type (type_))
+  else if (is_string_type (rhs.type_))
     new (&str_value_) std::shared_ptr<std::string>(rhs.str_value_);
-  else if (rhs.is_binary_file_type (type_))
+  else if (is_binary_file_type (rhs.type_))
     new (&file_value_) std::shared_ptr<std::vector<unsigned char>>(rhs.file_value_);
   else if (rhs.type_ == ANY)
     new (&any_value_) std::shared_ptr<ConstAny>(rhs.any_value_);
@@ -361,9 +361,9 @@ KnowledgeRecord::overwrite (KnowledgeRecord &&rhs)
     double_value_ = rhs.double_value_;
   else if (rhs.type_ == DOUBLE_ARRAY)
     new (&double_array_) std::shared_ptr<std::vector<double>>(std::move(rhs.double_array_));
-  else if (rhs.is_string_type (type_))
+  else if (is_string_type (rhs.type_))
     new (&str_value_) std::shared_ptr<std::string>(std::move(rhs.str_value_));
-  else if (rhs.is_binary_file_type (type_))
+  else if (is_binary_file_type (rhs.type_))
     new (&file_value_) std::shared_ptr<std::vector<unsigned char>>(std::move(rhs.file_value_));
   else if (rhs.type_ == ANY)
     new (&any_value_) std::shared_ptr<ConstAny>(std::move(rhs.any_value_));
@@ -442,7 +442,7 @@ KnowledgeRecord::operator+= (const knowledge::KnowledgeRecord & rhs)
 {
   if (is_integer_type (type_))
   {
-    if (rhs.is_integer_type (type_))
+    if (is_integer_type (rhs.type_))
       set_value (to_integer () + rhs.to_integer ());
     else
       set_value (to_integer () + rhs.to_double ());
@@ -510,7 +510,7 @@ KnowledgeRecord::operator-= (const knowledge::KnowledgeRecord & rhs)
 {
   if (is_integer_type (type_))
   {
-    if (rhs.is_integer_type (type_))
+    if (is_integer_type (rhs.type_))
       set_value (to_integer () - rhs.to_integer ());
     else
       set_value (to_integer () - rhs.to_double ());
@@ -532,7 +532,7 @@ KnowledgeRecord::operator*= (const knowledge::KnowledgeRecord & rhs)
 {
   if (is_integer_type (type_))
   {
-    if (rhs.is_integer_type (type_))
+    if (is_integer_type (rhs.type_))
       set_value (to_integer () * rhs.to_integer ());
     else
       set_value (to_integer () * rhs.to_double ());
@@ -554,7 +554,7 @@ KnowledgeRecord::operator/= (const knowledge::KnowledgeRecord & rhs)
 {
   if (is_integer_type (type_))
   {
-    if (rhs.is_integer_type (type_))
+    if (is_integer_type (rhs.type_))
     {
       Integer denom = rhs.to_integer ();
       if (denom == 0)
@@ -596,7 +596,7 @@ KnowledgeRecord::operator%= (const knowledge::KnowledgeRecord & rhs)
 {
   if (is_integer_type (type_))
   {
-    if (rhs.is_integer_type (type_))
+    if (is_integer_type (rhs.type_))
     {
       Integer denom = rhs.to_integer ();
       if (denom == 0)

--- a/include/madara/knowledge/KnowledgeRecord.inl
+++ b/include/madara/knowledge/KnowledgeRecord.inl
@@ -154,6 +154,19 @@ inline KnowledgeRecord::KnowledgeRecord (
 }
 
 inline KnowledgeRecord::KnowledgeRecord (
+  const CircBuf & buffer, logger::Logger & logger)
+: logger_ (&logger)
+{
+  emplace_circular_buffer (buffer);
+}
+
+inline KnowledgeRecord::KnowledgeRecord (
+  CircBuf && buffer, logger::Logger & logger) noexcept
+: logger_ (&logger)
+{
+  emplace_circular_buffer (std::move(buffer));
+}
+inline KnowledgeRecord::KnowledgeRecord (
     const knowledge::KnowledgeRecord & rhs)
 : logger_ (rhs.logger_),
   clock (rhs.clock),
@@ -174,12 +187,14 @@ inline KnowledgeRecord::KnowledgeRecord (
     double_value_ = rhs.double_value_;
   else if (rhs.type_ == DOUBLE_ARRAY)
     new (&double_array_) std::shared_ptr<std::vector<double>>(rhs.double_array_);
-  else if (rhs.is_string_type ())
+  else if (rhs.is_string_type (type_))
     new (&str_value_) std::shared_ptr<std::string>(rhs.str_value_);
-  else if (rhs.is_binary_file_type ())
+  else if (rhs.is_binary_file_type (type_))
     new (&file_value_) std::shared_ptr<std::vector<unsigned char>>(rhs.file_value_);
   else if (rhs.type_ == ANY)
     new (&any_value_) std::shared_ptr<ConstAny>(rhs.any_value_);
+  else if (rhs.type_ == BUFFER)
+    new (&buf_) std::shared_ptr<CircBuf>(rhs.buf_);
 }
 
 inline KnowledgeRecord::KnowledgeRecord (
@@ -203,12 +218,14 @@ inline KnowledgeRecord::KnowledgeRecord (
     double_value_ = rhs.double_value_;
   else if (rhs.type_ == DOUBLE_ARRAY)
     new (&double_array_) std::shared_ptr<std::vector<double>>(std::move(rhs.double_array_));
-  else if (rhs.is_string_type ())
+  else if (rhs.is_string_type (type_))
     new (&str_value_) std::shared_ptr<std::string>(std::move(rhs.str_value_));
-  else if (rhs.is_binary_file_type ())
+  else if (rhs.is_binary_file_type (type_))
     new (&file_value_) std::shared_ptr<std::vector<unsigned char>>(std::move(rhs.file_value_));
   else if (rhs.type_ == ANY)
     new (&any_value_) std::shared_ptr<ConstAny>(std::move(rhs.any_value_));
+  else if (rhs.type_ == BUFFER)
+    new (&buf_) std::shared_ptr<CircBuf>(std::move(rhs.buf_));
 
   rhs.type_ = EMPTY;
 }
@@ -219,7 +236,75 @@ inline KnowledgeRecord::~KnowledgeRecord () noexcept
 }
 
 inline void
+KnowledgeRecord::copy_metadata(const KnowledgeRecord &rhs)
+{
+  logger_ = rhs.logger_;
+  clock = rhs.clock;
+  toi = rhs.toi;
+  quality = rhs.quality;
+  write_quality = rhs.write_quality;
+}
+
+inline void
 KnowledgeRecord::set_value (const KnowledgeRecord &rhs)
+{
+  if (this == &rhs)
+    return;
+
+  if (has_history()) {
+    KnowledgeRecord tmp =
+      rhs.has_history() ?
+        rhs.get_newest() :
+        rhs;
+    buf_->emplace_back(std::move(tmp));
+  } else if (rhs.has_history()) {
+    overwrite(rhs.get_newest());
+  } else {
+    overwrite(rhs);
+  }
+}
+
+inline void
+KnowledgeRecord::set_value (KnowledgeRecord &&rhs)
+{
+  if (this == &rhs)
+    return;
+
+  if (has_history()) {
+    KnowledgeRecord tmp =
+      rhs.has_history() ?
+        std::move(rhs.ref_newest()) :
+        std::move(rhs);
+    buf_->emplace_back(std::move(tmp));
+  } else if (rhs.has_history()) {
+    overwrite(std::move(rhs.ref_newest()));
+  } else {
+    overwrite(std::move(rhs));
+  }
+}
+
+inline void
+KnowledgeRecord::set_full (const KnowledgeRecord &rhs)
+{
+  if (this == &rhs)
+    return;
+
+  copy_metadata(rhs);
+  set_value(rhs);
+}
+
+inline void
+KnowledgeRecord::set_full (KnowledgeRecord &&rhs)
+{
+  if (this == &rhs)
+    return;
+
+  copy_metadata(rhs);
+  set_value(std::move(rhs));
+}
+
+inline void
+KnowledgeRecord::overwrite (const KnowledgeRecord &rhs)
 {
   if (this == &rhs)
     return;
@@ -242,16 +327,18 @@ KnowledgeRecord::set_value (const KnowledgeRecord &rhs)
     double_value_ = rhs.double_value_;
   else if (rhs.type_ == DOUBLE_ARRAY)
     new (&double_array_) std::shared_ptr<std::vector<double>>(rhs.double_array_);
-  else if (rhs.is_string_type ())
+  else if (rhs.is_string_type (type_))
     new (&str_value_) std::shared_ptr<std::string>(rhs.str_value_);
-  else if (rhs.is_binary_file_type ())
+  else if (rhs.is_binary_file_type (type_))
     new (&file_value_) std::shared_ptr<std::vector<unsigned char>>(rhs.file_value_);
   else if (rhs.type_ == ANY)
     new (&any_value_) std::shared_ptr<ConstAny>(rhs.any_value_);
+  else if (rhs.type_ == BUFFER)
+    new (&buf_) std::shared_ptr<CircBuf>(rhs.buf_);
 }
 
 inline void
-KnowledgeRecord::set_value (KnowledgeRecord &&rhs)
+KnowledgeRecord::overwrite (KnowledgeRecord &&rhs)
 {
   if (this == &rhs)
     return;
@@ -274,12 +361,14 @@ KnowledgeRecord::set_value (KnowledgeRecord &&rhs)
     double_value_ = rhs.double_value_;
   else if (rhs.type_ == DOUBLE_ARRAY)
     new (&double_array_) std::shared_ptr<std::vector<double>>(std::move(rhs.double_array_));
-  else if (rhs.is_string_type ())
+  else if (rhs.is_string_type (type_))
     new (&str_value_) std::shared_ptr<std::string>(std::move(rhs.str_value_));
-  else if (rhs.is_binary_file_type ())
+  else if (rhs.is_binary_file_type (type_))
     new (&file_value_) std::shared_ptr<std::vector<unsigned char>>(std::move(rhs.file_value_));
   else if (rhs.type_ == ANY)
     new (&any_value_) std::shared_ptr<ConstAny>(std::move(rhs.any_value_));
+  else if (rhs.type_ == BUFFER)
+    new (&buf_) std::shared_ptr<CircBuf>(std::move(rhs.buf_));
 
   rhs.type_ = EMPTY;
 }
@@ -287,14 +376,10 @@ KnowledgeRecord::set_value (KnowledgeRecord &&rhs)
 inline KnowledgeRecord &
 KnowledgeRecord::operator= (const knowledge::KnowledgeRecord & rhs)
 {
-  set_value(rhs);
+  // copy fields not copied by overwrite
+  copy_metadata(rhs);
 
-  // copy fields not copied by set_value
-  logger_ = rhs.logger_;
-  clock = rhs.clock;
-  toi = rhs.toi;
-  quality = rhs.quality;
-  write_quality = rhs.write_quality;
+  overwrite(rhs);
 
   return *this;
 }
@@ -302,14 +387,10 @@ KnowledgeRecord::operator= (const knowledge::KnowledgeRecord & rhs)
 inline KnowledgeRecord &
 KnowledgeRecord::operator= (knowledge::KnowledgeRecord && rhs) noexcept
 {
-  set_value(rhs);
+  // copy fields not copied by overwrite
+  copy_metadata(rhs);
 
-  // copy fields not copied by set_value
-  logger_ = std::move(rhs.logger_);
-  clock = rhs.clock;
-  toi = rhs.toi;
-  quality = rhs.quality;
-  write_quality = rhs.write_quality;
+  overwrite(std::move(rhs));
 
   return *this;
 }
@@ -345,6 +426,10 @@ inline KnowledgeRecord
   {
     record.set_value (-double_value_);
   }
+  else if (has_history())
+  {
+    record.set_value (-get_newest());
+  }
 
   return record;
 }
@@ -355,18 +440,21 @@ inline KnowledgeRecord
 inline KnowledgeRecord &
 KnowledgeRecord::operator+= (const knowledge::KnowledgeRecord & rhs)
 {
-  if (is_integer_type ())
+  if (is_integer_type (type_))
   {
-    if (rhs.is_integer_type ())
+    if (rhs.is_integer_type (type_))
       set_value (to_integer () + rhs.to_integer ());
     else
       set_value (to_integer () + rhs.to_double ());
   }
-  else if (is_double_type ())
+  else if (is_double_type (type_))
     set_value (to_double () + rhs.to_double ());
 
-  else if (is_string_type ())
+  else if (is_string_type (type_))
     set_value (to_string () + rhs.to_string ());
+
+  else if (has_history ())
+    set_value (get_newest () + rhs);
 
   return *this;
 }
@@ -377,11 +465,17 @@ KnowledgeRecord::operator+= (const knowledge::KnowledgeRecord & rhs)
 inline KnowledgeRecord &
 KnowledgeRecord::operator-- (void)
 {
-  if (is_integer_type ())
+  if (is_integer_type (type_))
     set_value (to_integer () - 1);
 
-  else if (is_double_type ())
+  else if (is_double_type (type_))
     set_value (to_double () - 1);
+
+  else if (has_history ()) {
+    KnowledgeRecord tmp = get_newest();
+    --tmp;
+    set_value (std::move(tmp));
+  }
 
   return *this;
 }
@@ -392,11 +486,17 @@ KnowledgeRecord::operator-- (void)
 inline KnowledgeRecord &
 KnowledgeRecord::operator++ (void)
 {
-  if (is_integer_type ())
+  if (is_integer_type (type_))
     set_value (to_integer () + 1);
 
-  else if (is_double_type ())
+  else if (is_double_type (type_))
     set_value (to_double () + 1);
+
+  else if (has_history ()) {
+    KnowledgeRecord tmp = get_newest();
+    --tmp;
+    set_value (std::move(tmp));
+  }
 
 
   return *this;
@@ -408,15 +508,18 @@ KnowledgeRecord::operator++ (void)
 inline KnowledgeRecord &
 KnowledgeRecord::operator-= (const knowledge::KnowledgeRecord & rhs)
 {
-  if (is_integer_type ())
+  if (is_integer_type (type_))
   {
-    if (rhs.is_integer_type ())
+    if (rhs.is_integer_type (type_))
       set_value (to_integer () - rhs.to_integer ());
     else
       set_value (to_integer () - rhs.to_double ());
   }
-  else if (is_double_type () || is_string_type ())
+  else if (is_double_type (type_) || is_string_type (type_))
     set_value (to_double () - rhs.to_double ());
+
+  else if (has_history ())
+    set_value (get_newest () - rhs);
 
   return *this;
 }
@@ -427,15 +530,18 @@ KnowledgeRecord::operator-= (const knowledge::KnowledgeRecord & rhs)
 inline KnowledgeRecord &
 KnowledgeRecord::operator*= (const knowledge::KnowledgeRecord & rhs)
 {
-  if (is_integer_type ())
+  if (is_integer_type (type_))
   {
-    if (rhs.is_integer_type ())
+    if (rhs.is_integer_type (type_))
       set_value (to_integer () * rhs.to_integer ());
     else
       set_value (to_integer () * rhs.to_double ());
   }
-  else if (is_double_type () || is_string_type ())
+  else if (is_double_type (type_) || is_string_type (type_))
     set_value (to_double () * rhs.to_double ());
+
+  else if (has_history ())
+    set_value (get_newest () * rhs);
 
   return *this;
 }
@@ -446,9 +552,9 @@ KnowledgeRecord::operator*= (const knowledge::KnowledgeRecord & rhs)
 inline KnowledgeRecord &
 KnowledgeRecord::operator/= (const knowledge::KnowledgeRecord & rhs)
 {
-  if (is_integer_type ())
+  if (is_integer_type (type_))
   {
-    if (rhs.is_integer_type ())
+    if (rhs.is_integer_type (type_))
     {
       Integer denom = rhs.to_integer ();
       if (denom == 0)
@@ -466,7 +572,7 @@ KnowledgeRecord::operator/= (const knowledge::KnowledgeRecord & rhs)
         set_value (to_integer () / denom);
     }
   }
-  else if (is_double_type () || is_string_type ())
+  else if (is_double_type (type_) || is_string_type (type_))
   {
     double denom = rhs.to_double ();
 
@@ -475,6 +581,9 @@ KnowledgeRecord::operator/= (const knowledge::KnowledgeRecord & rhs)
     else
       set_value (to_double () / denom);
   }
+
+  else if (has_history ())
+    set_value (get_newest () / rhs);
 
   return *this;
 }
@@ -485,9 +594,9 @@ KnowledgeRecord::operator/= (const knowledge::KnowledgeRecord & rhs)
 inline KnowledgeRecord &
 KnowledgeRecord::operator%= (const knowledge::KnowledgeRecord & rhs)
 {
-  if (is_integer_type ())
+  if (is_integer_type (type_))
   {
-    if (rhs.is_integer_type ())
+    if (rhs.is_integer_type (type_))
     {
       Integer denom = rhs.to_integer ();
       if (denom == 0)
@@ -496,6 +605,9 @@ KnowledgeRecord::operator%= (const knowledge::KnowledgeRecord & rhs)
         set_value (to_integer () % denom);
     }
   }
+
+  else if (has_history ())
+    set_value (get_newest () % rhs);
 
   return *this;
 }
@@ -593,9 +705,9 @@ KnowledgeRecord::unshare (void)
 
   if (is_ref_counted ())
   {
-    if (is_string_type()) {
+    if (is_string_type(type_)) {
       emplace_string (*str_value_);
-    } else if (is_binary_file_type()) {
+    } else if (is_binary_file_type(type_)) {
       emplace_file (*file_value_);
     } else if (type_ == INTEGER_ARRAY) {
       emplace_integers (*int_array_);
@@ -603,6 +715,8 @@ KnowledgeRecord::unshare (void)
       emplace_doubles (*double_array_);
     } else if (type_ == ANY) {
       emplace_any (*any_value_);
+    } else if (type_ == BUFFER) {
+      emplace_circular_buffer (*buf_);
     }
   }
   shared_ = OWNED;
@@ -661,9 +775,9 @@ KnowledgeRecord::size (void) const
 {
   if (type_ == INTEGER || type_ == DOUBLE) {
     return 1;
-  } else if (is_string_type()) {
+  } else if (is_string_type(type_)) {
     return (uint32_t)str_value_->size () + 1;
-  } else if (is_binary_file_type()) {
+  } else if (is_binary_file_type(type_)) {
     return (uint32_t)file_value_->size ();
   } else if (type_ == INTEGER_ARRAY) {
     return (uint32_t)int_array_->size ();
@@ -673,6 +787,8 @@ KnowledgeRecord::size (void) const
     if (any_value_->supports_size ()) {
       return any_value_->size ();
     }
+  } else if (type_ == BUFFER) {
+    return ref_newest ().size ();
   }
   return 1;
 }
@@ -680,18 +796,20 @@ KnowledgeRecord::size (void) const
 inline uint32_t
 KnowledgeRecord::type (void) const
 {
-  return type_;
+  return has_history () ? ref_newest ().type_ : type_;
 }
 
 inline bool
 KnowledgeRecord::set_type (uint32_t type)
 {
   if (type == type_ ||
-      (is_string_type() && is_string_type(type)) ||
-      (is_binary_file_type() && is_binary_file_type(type))
+      (is_string_type(type_) && is_string_type(type)) ||
+      (is_binary_file_type(type_) && is_binary_file_type(type))
   ) {
     type_ = type;
     return true;
+  } else if (type_ == BUFFER) {
+    return ref_newest().set_type(type);
   }
   return false;
 }
@@ -721,11 +839,11 @@ KnowledgeRecord::get_encoded_size (void) const
   {
     buffer_size += sizeof (double) * double_array_->size();
   }
-  else if (is_string_type ())
+  else if (is_string_type (type_))
   {
     buffer_size += str_value_->size () + 1;
   }
-  else if (is_binary_file_type ())
+  else if (is_binary_file_type (type_))
   {
     buffer_size += file_value_->size ();
   }
@@ -733,6 +851,10 @@ KnowledgeRecord::get_encoded_size (void) const
   {
     //TODO calculate real size
     buffer_size += 1024;
+  }
+  else if (type_ == BUFFER)
+  {
+    ref_newest ().get_encoded_size ();
   }
 
   return buffer_size;
@@ -766,7 +888,7 @@ KnowledgeRecord::is_ref_counted (uint32_t type)
 inline bool
 KnowledgeRecord::is_string_type (void) const
 {
-  return is_string_type (type_);
+  return is_string_type (type ());
 }
 
 inline bool
@@ -778,7 +900,7 @@ KnowledgeRecord::is_string_type (uint32_t type)
 inline bool
 KnowledgeRecord::is_double_type (void) const
 {
-  return is_double_type (type_);
+  return is_double_type (type ());
 }
 
 inline bool
@@ -790,7 +912,7 @@ KnowledgeRecord::is_double_type (uint32_t type)
 inline bool
 KnowledgeRecord::is_integer_type (void) const
 {
-  return is_integer_type (type_);
+  return is_integer_type (type ());
 }
 
 
@@ -803,7 +925,7 @@ KnowledgeRecord::is_integer_type (uint32_t type)
 inline bool
 KnowledgeRecord::is_array_type (void) const
 {
-  return is_array_type (type_);
+  return is_array_type (type ());
 }
 
 inline bool
@@ -815,7 +937,7 @@ KnowledgeRecord::is_array_type (uint32_t type)
 inline bool
 KnowledgeRecord::is_image_type (void) const
 {
-  return is_image_type (type_);
+  return is_image_type (type ());
 }
 
 inline bool
@@ -827,7 +949,7 @@ KnowledgeRecord::is_image_type (uint32_t type)
 inline bool
 KnowledgeRecord::is_file_type (void) const
 {
-  return is_file_type (type_);
+  return is_file_type (type ());
 }
 
 inline bool
@@ -840,7 +962,7 @@ KnowledgeRecord::is_file_type (uint32_t type)
 inline bool
 KnowledgeRecord::is_binary_file_type (void) const
 {
-  return is_binary_file_type (type_);
+  return is_binary_file_type (type ());
 }
 
 inline bool
@@ -852,7 +974,7 @@ KnowledgeRecord::is_binary_file_type (uint32_t type)
 inline bool
 KnowledgeRecord::is_any_type (void) const
 {
-  return is_any_type (type_);
+  return is_any_type (type ());
 }
 
 inline bool
@@ -903,12 +1025,14 @@ KnowledgeRecord::clear_union (void) noexcept
       destruct(int_array_);
     else if (type_ == DOUBLE_ARRAY)
       destruct(double_array_);
-    else if (is_string_type ())
+    else if (is_string_type (type_))
       destruct(str_value_);
-    else if (is_binary_file_type ())
+    else if (is_binary_file_type (type_))
       destruct(file_value_);
     else if (type_ == ANY)
       destruct(any_value_);
+    else if (type_ == BUFFER)
+      destruct(buf_);
     shared_ = OWNED;
   }
 }
@@ -1119,8 +1243,8 @@ int64_t & buffer_remaining)
   return buffer;
 }
 
-// reset the value_ to an integer
-inline void  
+// reset the to empty
+inline void
 KnowledgeRecord::reset_value (void) noexcept
 {
   clear_value ();
@@ -1295,6 +1419,13 @@ template<typename T,
 inline void
 KnowledgeRecord::set_value (T new_value)
 {
+  if (has_history()) {
+    KnowledgeRecord tmp;
+    tmp.copy_metadata (*this);
+    tmp.set_value (new_value);
+    set_value (std::move (tmp));
+    return;
+  }
   if (type_ != INTEGER) {
     clear_union();
     type_ = INTEGER;
@@ -1337,6 +1468,13 @@ template<typename T,
 inline void
 KnowledgeRecord::set_value (T new_value)
 {
+  if (has_history()) {
+    KnowledgeRecord tmp;
+    tmp.copy_metadata (*this);
+    tmp.set_value (new_value);
+    set_value (std::move (tmp));
+    return;
+  }
   if (type_ != DOUBLE) {
     clear_union();
     type_ = DOUBLE;
@@ -1383,6 +1521,13 @@ template<typename T,
 inline void
 KnowledgeRecord::set_index (size_t index, T value)
 {
+  if (has_history())
+  {
+    KnowledgeRecord tmp = get_newest ();
+    tmp.set_index (index, value);
+    set_value (std::move (tmp));
+    return;
+  }
   if (type_ == DOUBLE_ARRAY)
   {
     // let the set_index for doubles take care of this
@@ -1416,6 +1561,13 @@ template<typename T,
 inline void
 KnowledgeRecord::set_index (size_t index, T value)
 {
+  if (has_history())
+  {
+    KnowledgeRecord tmp = get_newest ();
+    tmp.set_index (index, value);
+    set_value (std::move (tmp));
+    return;
+  }
   if (type_ == INTEGER_ARRAY)
   {
     std::vector<double> tmp (int_array_->begin (), int_array_->end ());
@@ -1446,9 +1598,11 @@ KnowledgeRecord::set_index (size_t index, T value)
 inline std::shared_ptr<const std::string>
 KnowledgeRecord::share_string() const
 {
-  if (is_string_type()) {
+  if (is_string_type(type_)) {
     shared_ = SHARED;
     return str_value_;
+  } else if (has_history()) {
+    return ref_newest().share_string();
   }
   return nullptr;
 }
@@ -1459,6 +1613,8 @@ KnowledgeRecord::share_integers() const
   if (type_ == INTEGER_ARRAY) {
     shared_ = SHARED;
     return int_array_;
+  } else if (has_history()) {
+    return ref_newest().share_integers();
   }
   return nullptr;
 }
@@ -1469,6 +1625,8 @@ KnowledgeRecord::share_doubles() const
   if (type_ == DOUBLE_ARRAY) {
     shared_ = SHARED;
     return double_array_;
+  } else if (has_history()) {
+    return ref_newest().share_doubles();
   }
   return nullptr;
 }
@@ -1476,9 +1634,11 @@ KnowledgeRecord::share_doubles() const
 inline std::shared_ptr<const std::vector<unsigned char>>
 KnowledgeRecord::share_binary() const
 {
-  if (is_binary_file_type()) {
+  if (is_binary_file_type(type_)) {
     shared_ = SHARED;
     return file_value_;
+  } else if (has_history()) {
+    return ref_newest().share_binary();
   }
   return nullptr;
 }
@@ -1486,9 +1646,11 @@ KnowledgeRecord::share_binary() const
 inline std::shared_ptr<const ConstAny>
 KnowledgeRecord::share_any() const
 {
-  if (is_any_type()) {
+  if (is_any_type(type_)) {
     shared_ = SHARED;
     return any_value_;
+  } else if (has_history()) {
+    return ref_newest().share_any();
   }
   return nullptr;
 }
@@ -1503,6 +1665,9 @@ inline char *
 KnowledgeRecord::write (char * buffer,
   int64_t & buffer_remaining) const
 {
+  if (has_history()) {
+    return ref_newest ().write (buffer, buffer_remaining);
+  }
   // format is [type | value_size | value]
 
   char * size_location = 0;
@@ -1553,7 +1718,7 @@ KnowledgeRecord::write (char * buffer,
     buffer_remaining -= sizeof (toi);
 
     // Remove the value from the buffer
-    if (is_string_type ())
+    if (is_string_type (type_))
     {
       // strings do not have to be converted
       if (buffer_remaining >= int64_t (size))
@@ -1626,7 +1791,7 @@ KnowledgeRecord::write (char * buffer,
         **/
       }
     }
-    else if (is_binary_file_type ())
+    else if (is_binary_file_type (type_))
     {
       // strings do not have to be converted
       if (buffer_remaining >= size)
@@ -1634,7 +1799,7 @@ KnowledgeRecord::write (char * buffer,
         memcpy (buffer, &(*file_value_)[0], size);
       }
     }
-    else if (is_any_type ())
+    else if (is_any_type (type_))
     {
       //madara_logger_ptr_log (logger_, logger::LOG_TRACE,
         //"KnowledgeRecord::write: encoding an Any type\n");

--- a/include/madara/knowledge/KnowledgeRecord.inl
+++ b/include/madara/knowledge/KnowledgeRecord.inl
@@ -157,14 +157,14 @@ inline KnowledgeRecord::KnowledgeRecord (
   const CircBuf & buffer, logger::Logger & logger)
 : logger_ (&logger)
 {
-  emplace_circular_buffer (buffer);
+  overwrite_circular_buffer (buffer);
 }
 
 inline KnowledgeRecord::KnowledgeRecord (
   CircBuf && buffer, logger::Logger & logger) noexcept
 : logger_ (&logger)
 {
-  emplace_circular_buffer (std::move(buffer));
+  overwrite_circular_buffer (std::move(buffer));
 }
 inline KnowledgeRecord::KnowledgeRecord (
     const knowledge::KnowledgeRecord & rhs)
@@ -256,7 +256,7 @@ KnowledgeRecord::set_value (const KnowledgeRecord &rhs)
       rhs.has_history() ?
         rhs.get_newest() :
         rhs;
-    buf_->emplace_back(std::move(tmp));
+    emplace_hist(std::move(tmp));
   } else if (rhs.has_history()) {
     overwrite(rhs.get_newest());
   } else {
@@ -275,7 +275,7 @@ KnowledgeRecord::set_value (KnowledgeRecord &&rhs)
       rhs.has_history() ?
         std::move(rhs.ref_newest()) :
         std::move(rhs);
-    buf_->emplace_back(std::move(tmp));
+    emplace_hist(std::move(tmp));
   } else if (rhs.has_history()) {
     overwrite(std::move(rhs.ref_newest()));
   } else {
@@ -716,7 +716,7 @@ KnowledgeRecord::unshare (void)
     } else if (type_ == ANY) {
       emplace_any (*any_value_);
     } else if (type_ == BUFFER) {
-      emplace_circular_buffer (*buf_);
+      overwrite_circular_buffer (*buf_);
     }
   }
   shared_ = OWNED;

--- a/include/madara/knowledge/KnowledgeUpdateSettings.h
+++ b/include/madara/knowledge/KnowledgeUpdateSettings.h
@@ -33,16 +33,7 @@ namespace madara
       /**
        * Constructor
        **/
-      KnowledgeUpdateSettings ()
-        : KnowledgeReferenceSettings (), 
-          treat_globals_as_locals (false),
-          signal_changes (true),
-          always_overwrite (false),
-          track_local_changes (true),
-          clock_increment (1),
-          treat_locals_as_globals (false)
-      {
-      }
+      KnowledgeUpdateSettings () = default;
   
       /**
        * Constructor
@@ -70,21 +61,24 @@ namespace madara
         bool t_always_expand = true,
         bool t_track_local_changes = true,
         uint64_t t_clock_increment = 1,
-        bool t_treat_locals_as_globals = false)
+        bool t_treat_locals_as_globals = false,
+        bool t_stream_changes = true)
         : KnowledgeReferenceSettings (t_always_expand),
           treat_globals_as_locals (t_treat_globals_as_locals),
           signal_changes (t_signal_changes),
           always_overwrite (t_always_overwrite),
           track_local_changes (t_track_local_changes),
           clock_increment (t_clock_increment),
-          treat_locals_as_globals (t_treat_locals_as_globals)
+          treat_locals_as_globals (t_treat_locals_as_globals),
+          stream_changes (t_stream_changes)
       {
       }
   
       /**
        * Constructor
        **/
-      KnowledgeUpdateSettings (const KnowledgeUpdateSettings & rhs)
+      KnowledgeUpdateSettings (const KnowledgeUpdateSettings & rhs) = default;
+      /*
         : KnowledgeReferenceSettings (rhs),
           treat_globals_as_locals (rhs.treat_globals_as_locals),
           signal_changes (rhs.signal_changes),
@@ -93,21 +87,19 @@ namespace madara
           clock_increment (rhs.clock_increment),
           treat_locals_as_globals (rhs.treat_locals_as_globals)
       {
-      }
+      }*/
 
 
       /**
        * Destructor
        **/
-      ~KnowledgeUpdateSettings ()
-      {
-      }
+      ~KnowledgeUpdateSettings () = default;
 
       /**
       * Toggle whether updates to global variables are treated as
       * local variables and not marked as modified to the transport
       **/
-      bool treat_globals_as_locals;
+      bool treat_globals_as_locals = false;
 
       /**
        * Toggle whether to signal changes have happened. Setting this
@@ -115,25 +107,25 @@ namespace madara
        * left to true. Setting this to false can result in problems
        * with wait statements.
        **/
-      bool signal_changes;
+      bool signal_changes = true;
       
       /**
       * Toggle for always overwriting records, regardless of quality,
       * clock values, etc.
       **/
-      bool always_overwrite;
+      bool always_overwrite = false;
       
       /**
        * Toggle for checkpointing support. If this is true, all changes
        * will be added to the local changes map in the knowledge base,
        * which is used by save_checkpoint to create diffs of knowledge
        **/
-      bool track_local_changes;
+      bool track_local_changes = true;
 
       /**
        * Default clock increment
        **/
-      uint64_t  clock_increment;
+      uint64_t  clock_increment = 1;
 
       /**
       * Toggle whether updates to local variables are treated as
@@ -145,7 +137,13 @@ namespace madara
       * remote system filters out the local variable changes with
       * an on-receive filter
       **/
-      bool treat_locals_as_globals;
+      bool treat_locals_as_globals = false;
+
+      /**
+       * Toggle for streaming support. If this is true, all changes
+       * will be streamed to the attached streamer, if any.
+       **/
+      bool stream_changes = true;
 
     };
   }

--- a/include/madara/knowledge/ThreadSafeContext.cpp
+++ b/include/madara/knowledge/ThreadSafeContext.cpp
@@ -2882,7 +2882,7 @@ checkpoint_write_record(
         madara_logger_ptr_log (logger_, logger::LOG_MINOR,
           "ThreadSafeContext::save_checkpoint:" \
           " checking record %s against prefix %s.\n",
-          name,
+          name.c_str(),
           settings.prefixes[j].c_str ());
 
         if (madara::utility::begins_with (

--- a/include/madara/knowledge/ThreadSafeContext.cpp
+++ b/include/madara/knowledge/ThreadSafeContext.cpp
@@ -16,6 +16,7 @@
 #include "madara/utility/Utility.h"
 
 #include "madara/knowledge/ThreadSafeContext.h"
+#include "madara/knowledge/ContextGuard.h"
 
 #include "madara/expression/Interpreter.h"
 #include "madara/transport/Transport.h"
@@ -2733,6 +2734,500 @@ ThreadSafeContext::load_context (
   return total_read;
 }
 
+static uint64_t
+update_checkpoint_header (
+  logger::Logger *logger_,
+  uint64_t clock_,
+  const CheckpointSettings & settings,
+  std::fstream &file,
+  FileHeader &meta,
+  transport::MessageHeader &checkpoint_header,
+  int64_t &buffer_remaining,
+  utility::ScopedArray<char> &buffer)
+{
+  char * current = buffer.get_ptr ();
+  const char * meta_reader = current;
+
+  // read the meta data at the front
+  // fseek (file, 0, SEEK_SET);
+  file.seekg (0, file.beg);
+  // size_t ret = fread (current, meta.encoded_size (), 1, file);
+
+  if (!file.read (buffer.get (), FileHeader::encoded_size ()))
+  {
+    madara_logger_ptr_log (logger_, logger::LOG_ERROR,
+      "ThreadSafeContext::save_checkpoint:" \
+      " failed to read existing file header: size=%d\n",
+      (int)meta.encoded_size ());
+
+    throw exceptions::MemoryException ("ThreadSafeContext::save_checkpoint:"
+      "Checkpoint file appears to have been corrupted. Bad header.");
+  }
+
+  meta_reader = meta.read (meta_reader, buffer_remaining);
+
+  madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+    "ThreadSafeContext::save_checkpoint:" \
+    " init file meta: size=%d, states=%d\n",
+    (int)meta.size, (int)meta.states);
+
+  if (settings.originator != "")
+  {
+    madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+      "ThreadSafeContext::save_checkpoint:" \
+      " setting file meta id to %s\n",
+      settings.originator.c_str ());
+
+    strncpy (meta.originator, settings.originator.c_str (),
+      sizeof (meta.originator) < settings.originator.size () + 1 ?
+      sizeof (meta.originator) : settings.originator.size () + 1);
+  }
+
+  // save the spot where the file ends
+  uint64_t checkpoint_start = meta.size +
+    (uint64_t)FileHeader::encoded_size ();
+
+  checkpoint_header.size = checkpoint_header.encoded_size ();
+
+  madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+    "ThreadSafeContext::save_checkpoint:" \
+    " meta.size=%d, chkpt.header.size=%d \n",
+    (int)meta.size, (int)checkpoint_header.size);
+
+  if (settings.override_timestamp)
+  {
+    meta.initial_timestamp = settings.initial_timestamp;
+    meta.last_timestamp = settings.last_timestamp;
+  }
+
+  if (settings.override_lamport)
+  {
+    checkpoint_header.clock = settings.initial_lamport_clock;
+  }
+  else
+  {
+    checkpoint_header.clock = clock_;
+  }
+
+  return checkpoint_start;
+}
+
+static char *
+init_checkpoint_header(
+  logger::Logger *logger_,
+  uint64_t clock_,
+  const CheckpointSettings & settings,
+  FileHeader &meta,
+  transport::MessageHeader &checkpoint_header,
+  int64_t &buffer_remaining,
+  utility::ScopedArray<char> &buffer)
+{
+  char * current = buffer.get_ptr ();
+
+  madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+    "ThreadSafeContext::save_checkpoint:" \
+    " creating file meta. file.meta.size=%d, state.size=%d\n",
+    (int)meta.size, (int)checkpoint_header.encoded_size ());
+
+  meta.size += checkpoint_header.encoded_size ();
+  checkpoint_header.size = checkpoint_header.encoded_size ();
+
+  if (settings.override_timestamp)
+  {
+    meta.initial_timestamp = settings.initial_timestamp;
+    meta.last_timestamp = settings.last_timestamp;
+  }
+
+  current = meta.write (current, buffer_remaining);
+
+  if (settings.override_lamport)
+  {
+    checkpoint_header.clock = settings.initial_lamport_clock;
+  }
+  else
+  {
+    checkpoint_header.clock = clock_;
+  }
+
+  current = checkpoint_header.write (current, buffer_remaining);
+
+  return current;
+}
+
+static void
+checkpoint_write_record(
+  logger::Logger *logger_,
+  const std::string &name,
+  const KnowledgeRecord *record,
+  const CheckpointSettings &settings,
+  transport::MessageHeader &checkpoint_header,
+  char * &current,
+  utility::ScopedArray<char> &buffer,
+  int64_t &buffer_remaining)
+{
+  if (record->exists ())
+  {
+    // check if the prefix is allowed
+    if (settings.prefixes.size () > 0)
+    {
+      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+        "ThreadSafeContext::save_checkpoint:" \
+        " we have %d prefixes to check against.\n",
+        (int)settings.prefixes.size ());
+
+      bool prefix_found = false;
+      for (size_t j = 0;
+           j < settings.prefixes.size () && !prefix_found; ++j)
+      {
+        madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+          "ThreadSafeContext::save_checkpoint:" \
+          " checking record %s against prefix %s.\n",
+          name,
+          settings.prefixes[j].c_str ());
+
+        if (madara::utility::begins_with (
+          record->to_string (), settings.prefixes[j]))
+        {
+          prefix_found = true;
+        }
+      } // end for j->prefixes.size
+
+      if (!prefix_found)
+      {
+        madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+          "ThreadSafeContext::save_checkpoint:" \
+          " record has the wrong prefix. Rejected.\n");
+
+        return;
+      }
+    } // end if prefixes exists
+
+    // get the encoded size of the record for checking buffer boundaries
+    int64_t encoded_size = record->get_encoded_size (name);
+
+    madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+      "ThreadSafeContext::save_checkpoint:" \
+      " estimated encoded size of update=%d bytes\n",
+      (int)encoded_size);
+
+    if (encoded_size > buffer_remaining)
+    {
+      throw exceptions::MemoryException (
+        "ThreadSafeContext::save_checkpoint: "
+        "%d buffer size is not big enough. Partial encoded size "
+        "already hit %d bytes. CheckpointSettings.buffer_size is "
+        "needs to be larger."
+        );
+    } // end if larger than buffer remaining
+
+    auto pre_write = current;
+    current = record->write (current, name, buffer_remaining);
+    encoded_size = current - pre_write;
+
+    ++checkpoint_header.updates;
+    checkpoint_header.size += (uint64_t)encoded_size;
+
+    madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+      "ThreadSafeContext::save_checkpoint:" \
+      " chkpt.header.size=%d, current->buffer delta=%d\n",
+      (int)checkpoint_header.size, (int)(current - buffer.get_ptr ()));
+  } // if record exists
+}
+
+namespace {
+  class ContextLocalModifiedsLister : public VariablesLister
+  {
+  public:
+    ContextLocalModifiedsLister(const ThreadSafeContext &context) :
+      context_(&context) {}
+
+    void start(const CheckpointSettings &settings) override
+    {
+      guard_.reset(new ContextGuard(*context_));
+      map_ = context_->get_local_modified();
+      iter_ = map_.begin();
+
+      if (settings.reset_checkpoint) {
+        clear_modifieds_ = true;
+      }
+    }
+
+    std::pair<const char *, const KnowledgeRecord *> next() override
+    {
+      std::pair<const char *, const KnowledgeRecord *> ret{nullptr, nullptr};
+
+      if (iter_ == map_.end()) {
+        guard_.reset();
+        if (clear_modifieds_) {
+          context_->reset_checkpoint();
+        }
+        return ret;
+      }
+
+      ret.first = iter_->first;
+      ret.second = iter_->second.get_record_unsafe();
+
+      ++iter_;
+
+      return ret;
+    }
+
+  private:
+    const ThreadSafeContext *context_;
+    std::unique_ptr<ContextGuard> guard_;
+    VariableReferenceMap map_;
+    VariableReferenceMap::iterator iter_;
+    bool clear_modifieds_ = false;
+  };
+}
+
+static void
+checkpoint_write_records (
+  const ThreadSafeContext &context,
+  logger::Logger *logger_,
+  const CheckpointSettings &settings,
+  transport::MessageHeader &checkpoint_header,
+  char * &current,
+  utility::ScopedArray<char> &buffer,
+  int64_t &buffer_remaining)
+{
+  ContextLocalModifiedsLister default_lister(context);
+
+  VariablesLister *lister = settings.variables_lister;
+
+  if (!lister) {
+    lister = &default_lister;
+  }
+
+  lister->start(settings);
+  for (;;) {
+    auto e = lister->next();
+    if (e.second == nullptr) {
+      break;
+    }
+
+    auto record = e.second;
+
+    checkpoint_write_record(logger_, e.first, record, settings,
+        checkpoint_header, current, buffer, buffer_remaining);
+  }
+}
+
+static void
+checkpoint_do_incremental (
+  const ThreadSafeContext &context,
+  logger::Logger *logger_,
+  uint64_t clock_,
+  const CheckpointSettings & settings,
+  std::fstream &file,
+  FileHeader &meta,
+  transport::MessageHeader &checkpoint_header)
+{
+  int64_t total_written (0);
+
+  int64_t max_buffer (settings.buffer_size);
+  int64_t buffer_remaining (max_buffer);
+  utility::ScopedArray <char> buffer = new char [max_buffer];
+
+  uint64_t checkpoint_start = update_checkpoint_header(logger_, clock_,
+      settings, file, meta, checkpoint_header,
+      buffer_remaining, buffer);
+
+  if (settings.variables_lister != nullptr ||
+      context.get_local_modified().size () != 0)
+  {
+    // skip over the checkpoint header. We'll write this later with the records
+
+    madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+      "ThreadSafeContext::save_checkpoint:" \
+      " fseek set to %d\n",
+       (int)(checkpoint_start));
+
+    // set the file pointer to the checkpoint header start
+    // fseek (file, (long)checkpoint_start, SEEK_SET);
+    file.seekp (checkpoint_start);
+
+    // start updates just past the checkpoint header's buffer location
+    char *current = checkpoint_header.write (
+        buffer.get_ptr (), buffer_remaining);
+
+    madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+      "ThreadSafeContext::save_checkpoint:" \
+      " chkpt.header.size=%d, current->buffer delta=%d\n",
+      (int) checkpoint_header.encoded_size (),
+      (int)(current - buffer.get_ptr ()));
+
+    checkpoint_write_records(context, logger_, settings,
+        checkpoint_header, current, buffer, buffer_remaining);
+
+    ++meta.states;
+
+    madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+      "ThreadSafeContext::save_checkpoint:" \
+      " writing final data to checkpoint for state #%d\n",
+      (int)meta.states);
+
+    madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+      "ThreadSafeContext::save_checkpoint:" \
+      " chkpt.header: size=%d, updates=%d\n",
+      (int)checkpoint_header.size, (int)checkpoint_header.updates);
+
+    int total_encoded = 0;
+
+    if (buffer_remaining != max_buffer)
+    {
+      total_written = (int64_t)(current - buffer.get_ptr ());
+
+      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+        "ThreadSafeContext::save_checkpoint:" \
+        " encoding %d bytes in checkpoint\n",
+        (int)total_written);
+
+      current = checkpoint_header.write (buffer.get_ptr (), buffer_remaining);
+
+      // call decode with any buffer filters
+      total_encoded = settings.encode (buffer.get_ptr (),
+        (int)total_written, (int)max_buffer);
+
+      if (total_encoded < 0)
+      {
+        throw exceptions::FilterException (
+          "ThreadSafeContext::save_context: "
+          "encode () returned a negative encoding size. Bad filter/encode.");
+      }
+
+      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+        "ThreadSafeContext::save_checkpoint:" \
+        " encoded %d bytes in buffer. Writing to disk at offset %d bytes\n",
+        (int)total_encoded, (int)checkpoint_start);
+
+      // if (settings.buffer_filters.size () > 0)
+      // {
+      //   total_encoded += (int)filters::BufferFilterHeader::encoded_size ();
+      // }
+
+      file.write (buffer.get_ptr (), total_encoded);
+      // fwrite (buffer.get_ptr (), (size_t)(total_encoded), 1, file);
+
+      meta.size += (uint64_t)total_encoded;
+
+      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+        "ThreadSafeContext::save_checkpoint:" \
+        " meta.size updated to %d bytes\n",
+        total_encoded, (int)meta.size);
+    }
+
+    buffer_remaining = max_buffer;
+    // fseek (file, (long)checkpoint_start, SEEK_SET);
+    file.seekp (0, file.beg);
+
+    madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+      "ThreadSafeContext::save_checkpoint:" \
+      " new file meta: size=%d, states=%d, "
+      " lastchkpt.start=%d, lastchkpt.size=%d, encoded=%d\n",
+      (int)meta.size, (int)meta.states,
+      (int)checkpoint_start, (int)checkpoint_header.size,
+      (int)total_encoded);
+
+    // update the meta data at the front
+    // fseek (file, 0, SEEK_SET);
+
+    madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+      "ThreadSafeContext::save_checkpoint:" \
+      " updating file meta data at beginning in the file\n");
+    buffer_remaining = max_buffer;
+    current = meta.write (buffer.get_ptr (), buffer_remaining);
+
+    // fwrite (buffer.get_ptr (), current - buffer.get_ptr (), 1, file);
+    file.write (buffer.get (), FileHeader::encoded_size ());
+
+  } // if there are local checkpointing records
+
+  // fclose (file);
+  file.close ();
+}
+
+static void
+checkpoint_do_initial (
+  const ThreadSafeContext &context,
+  logger::Logger *logger_,
+  uint64_t clock_,
+  const CheckpointSettings & settings,
+  std::fstream &file,
+  FileHeader &meta,
+  transport::MessageHeader &checkpoint_header)
+{
+  int file_header_size = (int)FileHeader::encoded_size ();
+
+  int64_t max_buffer (settings.buffer_size);
+  int64_t buffer_remaining (max_buffer);
+  utility::ScopedArray <char> buffer = new char [max_buffer];
+
+  char * current = init_checkpoint_header(logger_, clock_,
+      settings, meta, checkpoint_header,
+      buffer_remaining, buffer);
+
+  madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+    "ThreadSafeContext::save_checkpoint:" \
+    " writing diff records\n");
+
+  checkpoint_write_records(context, logger_, settings,
+      checkpoint_header, current, buffer, buffer_remaining);
+
+  char * final_position = current;
+  int full_buffer = final_position - buffer.get_ptr ();
+
+  madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+    "ThreadSafeContext::save_checkpoint:" \
+    " final_position indicates a buffer of %d bytes," \
+    " encode buffer is %d bytes\n",
+    full_buffer, full_buffer - file_header_size
+  );
+
+  // write the final sizes for the checkpoint at [108]
+  current = checkpoint_header.write (
+    buffer.get_ptr () + file_header_size, max_buffer);
+
+  // call decode with any buffer filters on [108]
+  int total = settings.encode (buffer.get_ptr () + 
+    (int)FileHeader::encoded_size (),
+    (int)(full_buffer - file_header_size), (int)max_buffer);
+
+  if (total < 0)
+  {
+    throw exceptions::FilterException (
+      "ThreadSafeContext::save_checkpoint: "
+      "encode () returned a negative encoding size. Bad filter/encode.");
+  }
+
+  meta.size = (uint64_t)total;
+
+  current = meta.write (buffer.get_ptr (), max_buffer);
+
+  // update the meta data at the front
+  // fseek (file, 0, SEEK_SET);
+  file.seekp (0, file.beg);
+
+  madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+    "ThreadSafeContext::save_checkpoint:" \
+    " encoding with buffer filters: meta.size=%d, chkpt.size=%d, "
+    "encoded=%d, chkpt.offset=%d.\n",
+    (int)meta.size, (int)checkpoint_header.size,
+    (int)total, file_header_size);
+
+  // fwrite (buffer.get_ptr (),
+  //   (size_t)total + (size_t)FileHeader::encoded_size (), 1, file);
+  file.write (buffer.get (),
+    (size_t)total + (size_t)file_header_size);
+
+  madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+    "ThreadSafeContext::save_checkpoint:" \
+    " wrote: %d bytes to file from beginning.\n",
+    (int)total + (int)FileHeader::encoded_size ());
+
+  // fclose (file);
+  file.close ();
+}
 
 int64_t
 ThreadSafeContext::save_checkpoint (
@@ -2742,273 +3237,25 @@ ThreadSafeContext::save_checkpoint (
     "ThreadSafeContext::save_checkpoint:" \
     " opening file %s\n", settings.filename.c_str ());
 
-  int64_t total_written (0);
   // FILE * file = fopen (settings.filename.c_str (), "rb+");
   std::fstream file (settings.filename,
     std::ios::in | std::ios::out | std::ios::binary);
 
   FileHeader meta;
   transport::MessageHeader checkpoint_header;
-  int file_header_size = (int)FileHeader::encoded_size ();
   //int chkpt_header_size = (int)checkpoint_header.encoded_size ();
 
   if (file)
   {
-    int64_t max_buffer (settings.buffer_size);
-    int64_t buffer_remaining (max_buffer);
-    utility::ScopedArray <char> buffer = new char [max_buffer];
-
-    char * current = buffer.get_ptr ();
-    const char * meta_reader = current;
-
-    // read the meta data at the front
-    // fseek (file, 0, SEEK_SET);
-    file.seekg (0, file.beg);
-    // size_t ret = fread (current, meta.encoded_size (), 1, file);
-
-    if (!file.read (buffer.get (), FileHeader::encoded_size ()))
-    {
-      madara_logger_ptr_log (logger_, logger::LOG_ERROR,
-        "ThreadSafeContext::save_checkpoint:" \
-        " failed to read existing file header: size=%d\n",
-        (int)meta.encoded_size ());
-
-      throw exceptions::MemoryException ("ThreadSafeContext::save_checkpoint:"
-        "Checkpoint file appears to have been corrupted. Bad header.");
-    }
-
-    meta_reader = meta.read (meta_reader, buffer_remaining);
-
-    madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-      "ThreadSafeContext::save_checkpoint:" \
-      " init file meta: size=%d, states=%d\n",
-      (int)meta.size, (int)meta.states);
-
-    if (settings.originator != "")
-    {
-      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-        "ThreadSafeContext::save_checkpoint:" \
-        " setting file meta id to %s\n",
-        settings.originator.c_str ());
-
-      strncpy (meta.originator, settings.originator.c_str (),
-        sizeof (meta.originator) < settings.originator.size () + 1 ?
-        sizeof (meta.originator) : settings.originator.size () + 1);
-    }
-
-    // save the spot where the file ends
-    uint64_t checkpoint_start = meta.size +
-      (uint64_t)FileHeader::encoded_size ();
-
-    checkpoint_header.size = checkpoint_header.encoded_size ();
-
-    madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-      "ThreadSafeContext::save_checkpoint:" \
-      " meta.size=%d, chkpt.header.size=%d \n",
-      (int)meta.size, (int)checkpoint_header.size);
-
-    if (settings.override_timestamp)
-    {
-      meta.initial_timestamp = settings.initial_timestamp;
-      meta.last_timestamp = settings.last_timestamp;
-    }
-
-    if (settings.override_lamport)
-    {
-      checkpoint_header.clock = settings.initial_lamport_clock;
-    }
-    else
-    {
-      checkpoint_header.clock = clock_;
-    }
-
-    const knowledge::VariableReferenceMap & local_records = this->get_local_modified ();
-
-    if (local_records.size () != 0)
-    {
-      // skip over the checkpoint header. We'll write this later with the records
-
-      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-        "ThreadSafeContext::save_checkpoint:" \
-        " fseek set to %d\n",
-         (int)(checkpoint_start));
-
-      // set the file pointer to the checkpoint header start
-      // fseek (file, (long)checkpoint_start, SEEK_SET);
-      file.seekp (checkpoint_start);
-
-      // start updates just past the checkpoint header's buffer location
-      current = checkpoint_header.write (buffer.get_ptr (), buffer_remaining);
-
-      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-        "ThreadSafeContext::save_checkpoint:" \
-        " chkpt.header.size=%d, current->buffer delta=%d\n",
-        (int) checkpoint_header.encoded_size (),
-        (int)(current - buffer.get_ptr ()));
-
-      {
-        // lock the context
-        MADARA_GUARD_TYPE guard (mutex_);
-
-        for (const auto &e : local_records)
-        {
-          auto record = e.second.get_record_unsafe();
-
-          if (record->exists ())
-          {
-            // check if the prefix is allowed
-            if (settings.prefixes.size () > 0)
-            {
-              bool prefix_found = false;
-              for (size_t j = 0;
-                   j < settings.prefixes.size () && !prefix_found; ++j)
-              {
-                if (madara::utility::begins_with (
-                  record->to_string (), settings.prefixes[j]))
-                {
-                  prefix_found = true;
-                }
-              } // end for j->prefixes.size
-
-              if (!prefix_found)
-                continue;
-            } // end if prefixes exists
-
-            // get the encoded size of the record for checking buffer boundaries
-            int64_t encoded_size = record->get_encoded_size (e.first);
-
-            madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-              "ThreadSafeContext::save_checkpoint:" \
-              " estimated encoded size of update=%d bytes\n",
-              (int)encoded_size);
-
-            if (encoded_size > buffer_remaining)
-            {
-              throw exceptions::MemoryException (
-                "ThreadSafeContext::save_checkpoint: "
-                "%d buffer size is not big enough. Partial encoded size "
-                "already hit %d bytes. CheckpointSettings.buffer_size is "
-                "needs to be larger."
-                );
-            } // end if larger than buffer remaining
-
-            auto pre_write = current;
-            current = record->write (current, e.first, buffer_remaining);
-            encoded_size = current - pre_write;
-
-            checkpoint_header.size += (uint64_t)encoded_size;
-            ++checkpoint_header.updates;
-
-            madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-              "ThreadSafeContext::save_checkpoint:" \
-              " chkpt.header.size=%d, current->buffer delta=%d\n",
-              (int)checkpoint_header.size, (int)(current - buffer.get_ptr ()));
-          } // if record exists
-        } // for all records
-
-        ++meta.states;
-
-        if (settings.reset_checkpoint)
-        {
-          madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-            "ThreadSafeContext::save_checkpoint:" \
-            " resetting checkpoint. Next checkpoint starts fresh here\n");
-
-          reset_checkpoint ();
-        }
-      } // end scoped Guard for context
-
-      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-        "ThreadSafeContext::save_checkpoint:" \
-        " writing final data to checkpoint for state #%d\n",
-        (int)meta.states);
-
-      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-        "ThreadSafeContext::save_checkpoint:" \
-        " chkpt.header: size=%d, updates=%d\n",
-        (int)checkpoint_header.size, (int)checkpoint_header.updates);
-
-      int total_encoded = 0;
-
-      if (buffer_remaining != max_buffer)
-      {
-        total_written = (int64_t)(current - buffer.get_ptr ());
-
-        madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-          "ThreadSafeContext::save_checkpoint:" \
-          " encoding %d bytes in checkpoint\n",
-          (int)total_written);
-
-        current = checkpoint_header.write (buffer.get_ptr (), buffer_remaining);
-        
-        // call decode with any buffer filters
-        total_encoded = settings.encode (buffer.get_ptr (),
-          (int)total_written, (int)max_buffer);
-
-        if (total_encoded < 0)
-        {
-          throw exceptions::FilterException (
-            "ThreadSafeContext::save_context: "
-            "encode () returned a negative encoding size. Bad filter/encode.");
-        }
-
-        madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-          "ThreadSafeContext::save_checkpoint:" \
-          " encoded %d bytes in buffer. Writing to disk at offset %d bytes\n",
-          (int)total_encoded, (int)checkpoint_start);
-
-        // if (settings.buffer_filters.size () > 0)
-        // {
-        //   total_encoded += (int)filters::BufferFilterHeader::encoded_size ();
-        // }
-
-        file.write (buffer.get_ptr (), total_encoded);
-        // fwrite (buffer.get_ptr (), (size_t)(total_encoded), 1, file);
-          
-        meta.size += (uint64_t)total_encoded;
-
-        madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-          "ThreadSafeContext::save_checkpoint:" \
-          " meta.size updated to %d bytes\n",
-          total_encoded, (int)meta.size);
-      }
-
-      buffer_remaining = max_buffer;
-      // fseek (file, (long)checkpoint_start, SEEK_SET);
-      file.seekp (0, file.beg);
-
-      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-        "ThreadSafeContext::save_checkpoint:" \
-        " new file meta: size=%d, states=%d, "
-        " lastchkpt.start=%d, lastchkpt.size=%d, encoded=%d\n",
-        (int)meta.size, (int)meta.states,
-        (int)checkpoint_start, (int)checkpoint_header.size,
-        (int)total_encoded);
-  
-      // update the meta data at the front
-      // fseek (file, 0, SEEK_SET);
-
-      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-        "ThreadSafeContext::save_checkpoint:" \
-        " updating file meta data at beginning in the file\n");
-  
-      buffer_remaining = max_buffer;
-      current = meta.write (buffer.get_ptr (), buffer_remaining);
-
-      // fwrite (buffer.get_ptr (), current - buffer.get_ptr (), 1, file);
-      file.write (buffer.get (), FileHeader::encoded_size ());
-
-    } // if there are local checkpointing records
-
-    // fclose (file);
-    file.close ();
+    checkpoint_do_incremental(*this, logger_, clock_,
+      settings, file, meta, checkpoint_header);
   } // if file is opened
   else
   {
     madara_logger_ptr_log (logger_, logger::LOG_MINOR,
       "ThreadSafeContext::save_checkpoint:" \
       " checkpoint doesn't exist. Creating.\n");
-    
+
     file.open (settings.filename, std::ios::out | std::ios::binary);
 
     meta.states = 1;
@@ -3016,179 +3263,9 @@ ThreadSafeContext::save_checkpoint (
       sizeof (meta.originator) < settings.originator.size () + 1 ?
       sizeof (meta.originator) : settings.originator.size () + 1);
 
-    if (file)
-    {
-      int64_t max_buffer (settings.buffer_size);
-      int64_t buffer_remaining (max_buffer);
-      utility::ScopedArray <char> buffer = new char [max_buffer];
 
-      char * current = buffer.get_ptr ();
-
-      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-        "ThreadSafeContext::save_checkpoint:" \
-        " creating file meta. file.meta.size=%d, state.size=%d\n",
-        (int)meta.size, (int)checkpoint_header.encoded_size ());
-    
-      meta.size += checkpoint_header.encoded_size ();
-      checkpoint_header.size = checkpoint_header.encoded_size ();
-
-      if (settings.override_timestamp)
-      {
-        meta.initial_timestamp = settings.initial_timestamp;
-        meta.last_timestamp = settings.last_timestamp;
-      }
-
-      current = meta.write (current, buffer_remaining);
-
-      if (settings.override_lamport)
-      {
-        checkpoint_header.clock = settings.initial_lamport_clock;
-      }
-      else
-      {
-        checkpoint_header.clock = clock_;
-      }
-      
-      current = checkpoint_header.write (current, buffer_remaining);
-
-      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-        "ThreadSafeContext::save_checkpoint:" \
-        " writing diff records\n");
-    
-      // lock the context
-      MADARA_GUARD_TYPE guard (mutex_);
-
-      const knowledge::VariableReferenceMap & local_records = this->get_local_modified ();
-
-      for (const auto &e : local_records)
-      {
-        auto record = e.second.get_record_unsafe();
-
-        if (record->exists ())
-        {
-          // check if the prefix is allowed
-          if (settings.prefixes.size () > 0)
-          {
-            madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-              "ThreadSafeContext::save_checkpoint:" \
-              " we have %d prefixes to check against.\n",
-              (int)settings.prefixes.size ());
-
-            bool prefix_found = false;
-            for (size_t j = 0;
-                 j < settings.prefixes.size () && !prefix_found; ++j)
-            {
-              madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-                "ThreadSafeContext::save_checkpoint:" \
-                " checking record %s against prefix %s.\n",
-                e.first,
-                settings.prefixes[j].c_str ());
-
-              if (madara::utility::begins_with (
-                    e.first, settings.prefixes[j]))
-              {
-                madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-                  "ThreadSafeContext::save_checkpoint:" \
-                  " record has the correct prefix.\n");
-
-                prefix_found = true;
-              }
-            }
-
-            if (!prefix_found)
-            {
-              madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-                "ThreadSafeContext::save_checkpoint:" \
-                " record has the wrong prefix. Rejected.\n");
-
-              continue;
-            }
-          }
-
-          // get the encoded size of the record for checking buffer boundaries
-          int64_t encoded_size = record->get_encoded_size (e.first);
-
-          madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-            "ThreadSafeContext::save_checkpoint:" \
-            " estimated encoded size of update=%d bytes\n",
-            (int)encoded_size);
-
-          auto pre_write = current;
-          current = record->write (current, e.first, buffer_remaining);
-          encoded_size = current - pre_write;
-
-          ++checkpoint_header.updates;
-          //meta.size += encoded_size;
-          checkpoint_header.size += encoded_size;
-
-          madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-            "ThreadSafeContext::save_checkpoint:" \
-            " current->buffer delta=%d bytes\n",
-            (int)(current - buffer.get_ptr ()));
-    
-        }
-      }
-    
-      char * final_position = current;
-      int full_buffer = final_position - buffer.get_ptr ();
-
-      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-        "ThreadSafeContext::save_checkpoint:" \
-        " final_position indicates a buffer of %d bytes," \
-        " encode buffer is %d bytes\n",
-        full_buffer, full_buffer - file_header_size
-      );
-
-      // write the final sizes for the checkpoint at [108]
-      current = checkpoint_header.write (
-        buffer.get_ptr () + file_header_size, max_buffer);
-
-      // call decode with any buffer filters on [108]
-      int total = settings.encode (buffer.get_ptr () + 
-        (int)FileHeader::encoded_size (),
-        (int)(full_buffer - file_header_size), (int)max_buffer);
-
-      if (total < 0)
-      {
-        throw exceptions::FilterException (
-          "ThreadSafeContext::save_checkpoint: "
-          "encode () returned a negative encoding size. Bad filter/encode.");
-      }
-
-      meta.size = (uint64_t)total;
-
-      current = meta.write (buffer.get_ptr (), max_buffer);
-
-      // update the meta data at the front
-      // fseek (file, 0, SEEK_SET);
-      file.seekp (0, file.beg);
-
-      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-        "ThreadSafeContext::save_checkpoint:" \
-        " encoding with buffer filters: meta.size=%d, chkpt.size=%d, "
-        "encoded=%d, chkpt.offset=%d.\n",
-        (int)meta.size, (int)checkpoint_header.size,
-        (int)total, file_header_size);
-
-      // fwrite (buffer.get_ptr (),
-      //   (size_t)total + (size_t)FileHeader::encoded_size (), 1, file);
-      file.write (buffer.get (),
-        (size_t)total + (size_t)file_header_size);
-
-      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-        "ThreadSafeContext::save_checkpoint:" \
-        " wrote: %d bytes to file from beginning.\n",
-        (int)total + (int)FileHeader::encoded_size ());
-
-      // fclose (file);
-      file.close ();
-      if (settings.reset_checkpoint)
-      {
-        reset_checkpoint ();
-      }
-
-    } // if the new file creation for wb was successful
-    else
+    // if the new file creation for wb was unsuccessful
+    if (!file)
     {
       madara_logger_ptr_log (logger_, logger::LOG_MINOR,
         "ThreadSafeContext::save_checkpoint:" \
@@ -3197,6 +3274,9 @@ ThreadSafeContext::save_checkpoint (
 
       return -1;
     }
+
+    checkpoint_do_initial(*this, logger_, clock_,
+      settings, file, meta, checkpoint_header);
   } // end if we need to create a new file
 
   return checkpoint_header.size;

--- a/include/madara/knowledge/ThreadSafeContext.cpp
+++ b/include/madara/knowledge/ThreadSafeContext.cpp
@@ -2387,351 +2387,372 @@ ThreadSafeContext::file_to_string (
   return std::string ();
 }
 
-int64_t
-ThreadSafeContext::load_context (
-  CheckpointSettings & checkpoint_settings,
-  const KnowledgeUpdateSettings & update_settings)
+void CheckpointReader::start()
 {
+  if (stage != 0) {
+    return;
+  }
+
   madara_logger_ptr_log (logger_, logger::LOG_MAJOR,
     "ThreadSafeContext::load_context:" \
     " opening file %s\n", checkpoint_settings.filename.c_str ());
 
-//  FILE * file = fopen (checkpoint_settings.filename.c_str (), "rb");
-
-  std::ifstream file (checkpoint_settings.filename.c_str (),
+  file.open(checkpoint_settings.filename.c_str (),
     std::ios::in | std::ios::binary);
 
-  int64_t total_read (0);
-
-  if (checkpoint_settings.clear_knowledge)
-  {
-    this->clear ();
-  }
-
-  if (file)
-  {
-    FileHeader meta;
-    int64_t max_buffer (checkpoint_settings.buffer_size);
-    int64_t buffer_remaining (max_buffer);
-
-    utility::ScopedArray <char> buffer = new char[max_buffer];
-    char * current = buffer.get_ptr ();
-
-    file.seekg (0, file.end);
-    int length = file.tellg();
-    file.seekg (0, file.beg);
-
-    madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-      "ThreadSafeContext::load_context:" \
-      " file contains %d bytes.\n",
-      (int)length);
-
-    if (!file.read (buffer.get (), FileHeader::encoded_size ()))
-    {
-      std::stringstream message;
-      message << "ThreadSafeContext::load_context: ";
-      message << "file ";
-      message << checkpoint_settings.filename;
-      message << " does not have enough room for an appropriate header";
-      throw exceptions::FileException (message.str ());
-    }
-    total_read = file.tellg();
-
-    buffer_remaining = (int64_t)total_read;
-
-    madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-      "ThreadSafeContext::load_context:" \
-      " reading file: %d bytes read.\n",
-      (int)total_read);
-
-    size_t checkpoint_start = (size_t)FileHeader::encoded_size ();
-
-    if (total_read >= FileHeader::encoded_size () &&
-      FileHeader::file_header_test (current))
-    {
-      // if there was something in the file, and it was the right header
-
-      current = (char *)meta.read (current, buffer_remaining);
-
-      checkpoint_settings.initial_timestamp = meta.initial_timestamp;
-      checkpoint_settings.last_timestamp = meta.last_timestamp;
-      checkpoint_settings.originator = meta.originator;
-      checkpoint_settings.states = meta.states;
-      checkpoint_settings.version = utility::to_string_version (
-        meta.karl_version);
-
-      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-                "ThreadSafeContext::load_context:" \
-                " read File meta. Meta.size=%d\n", (int)meta.size);
-
-      /**
-      * check that there is more than one state and that the rest of
-      * the file is sufficient to at least be a message header (what
-      * we use as a checkpoint header
-      **/
-      if (meta.states > 0)
-      {
-        for (uint64_t state = 0; state < meta.states &&
-               state <= checkpoint_settings.last_state; ++state)
-        {
-          uint64_t checkpoint_size; 
-
-          madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-            "ThreadSafeContext::load_context:" \
-            " reading 64bit unsigned size at %d byte file offset\n",
-            (int)checkpoint_start);
-
-          // set the file pointer to the checkpoint header start
-          //fseek (file, (long)checkpoint_start, SEEK_SET);
-          file.seekg (checkpoint_start, file.beg);
-
-          if (!file.read ((char *)&checkpoint_size, sizeof (checkpoint_size)))
-          {
-            std::stringstream message;
-            message << "ThreadSafeContext::load_context: ";
-            message << "file ";
-            message << checkpoint_settings.filename;
-            message << " does not have enough room for a checkpoint";
-            throw exceptions::FileException (message.str ());
-          }
-
-          // total_read = fread (&checkpoint_size,
-          //   1, sizeof (checkpoint_size), file);
-
-          total_read = sizeof (checkpoint_size);
-
-          checkpoint_size = utility::endian_swap (checkpoint_size);
-
-          if (checkpoint_settings.buffer_filters.size () > 0)
-          {
-            checkpoint_size += filters::BufferFilterHeader::encoded_size ();
-          }
-
-          madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-            "ThreadSafeContext::load_context:" \
-            " %d state checkpoint size is %d\n",
-            (int)state, (int)checkpoint_size);
-
-          // set the file pointer to the checkpoint header start
-          //fseek (file, (long)checkpoint_start, SEEK_SET);
-          file.seekg (checkpoint_start, file.beg);
-
-          // set the file pointer to the checkpoint header start
-          // fseek (file, (long)checkpoint_start, SEEK_SET);
-
-          checkpoint_start += checkpoint_size;
-
-          madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-            "ThreadSafeContext::load_context:" \
-            " reading %d bytes for full checkpoint\n",
-            (int)checkpoint_size);
-
-          // total_read = fread (buffer.get_ptr (),
-          //   1, (size_t)checkpoint_size, file);
-
-          if (!file.read (buffer.get (), checkpoint_size))
-          {
-            std::stringstream message;
-            message << "ThreadSafeContext::load_context: ";
-            message << "file ";
-            message << checkpoint_settings.filename;
-            message << " does not have enough room for ";
-            message << checkpoint_size;
-            message << " bytes noted in header";
-            throw exceptions::FileException (message.str ());
-          }
-          total_read = (int64_t)checkpoint_size;
-
-          current = buffer.get_ptr ();
-
-          madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-            "ThreadSafeContext::load_context:" \
-            " read %d bytes\n",
-            (int)total_read);
-
-          buffer_remaining = (int64_t)total_read;
-
-          madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-            "ThreadSafeContext::load_context:" \
-            " decoding with %d buffer filters with initial size of "
-            "%d bytes and total buffer of %d bytes\n",
-            (int)checkpoint_settings.buffer_filters.size (),
-            (int)total_read, (int)max_buffer);
-
-          // call decode with any buffer filters
-          buffer_remaining = (int64_t)checkpoint_settings.decode (current,
-            (int)total_read, (int)max_buffer);
-
-          if (buffer_remaining <= 0)
-          {
-            throw exceptions::FilterException (
-              "ThreadSafeContext::load_context: "
-              "decode () returned a negative encoding size. Bad filter/encode.");
-          }
-
-          if (buffer_remaining > (int64_t)
-            transport::MessageHeader::static_encoded_size ())
-          {
-            transport::MessageHeader checkpoint_header;
-
-            madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-              "ThreadSafeContext::load_context:" \
-              " Reading a checkpoint header with %d byte buffer remaining\n",
-              (int)buffer_remaining);
-
-            current = (char *)checkpoint_header.read (current, buffer_remaining);
-
-            if (state == 0)
-            {
-              checkpoint_settings.initial_lamport_clock = checkpoint_header.clock;
-            }
-
-            if (state == meta.states - 1)
-            {
-              checkpoint_settings.last_lamport_clock = checkpoint_header.clock;
-            }
-
-            uint64_t updates_size = checkpoint_header.size -
-              checkpoint_header.encoded_size ();
-
-            madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-                "ThreadSafeContext::load_context:" \
-                " read Checkpoint header. header.size=%d, updates.size=%d\n",
-                (int)checkpoint_header.size, (int)updates_size);
-
-            /**
-            * What we read into the checkpoint_header will dictate our
-            * max_buffer. We want to make this checkpoint_header size into
-            * something reasonable.
-            **/
-            if (updates_size > (uint64_t)buffer_remaining)
-            {
-              /**
-              * create a new array and copy the remaining elements
-              * from buffer_remaining
-              **/
-              // utility::ScopedArray <char> new_buffer =
-              //   new char[updates_size];
-              // memcpy (new_buffer.get_ptr (), current,
-              //   (size_t)buffer_remaining);
-
-              // // read the rest of checkpoint into new buffer
-              // total_read += fread (new_buffer.get_ptr () + buffer_remaining, 1,
-              //   updates_size
-              //   - (uint64_t)buffer_remaining
-              //   - checkpoint_header.encoded_size (), file);
-
-              // // update other variables
-              // max_buffer = updates_size;
-              // buffer_remaining = checkpoint_header.size
-              //   - checkpoint_header.encoded_size ();
-              // current = new_buffer.get_ptr ();
-              // buffer = new_buffer;
-
-              throw exceptions::MemoryException (
-                "ThreadSafeContext::load_context: "
-                "Not enough room in buffer for checkpoint"
-              );
-            } // end if allocation is needed
-
-            madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-                "ThreadSafeContext::load_context:" \
-                " state=%d, initial_state=%d, last_state=%d\n",
-                (int)state, (int)checkpoint_settings.initial_state,
-                (int)checkpoint_settings.last_state);
-
-            if (state <= checkpoint_settings.last_state &&
-                state >= checkpoint_settings.initial_state)
-            {
-              for (uint32_t update = 0;
-                update < checkpoint_header.updates; ++update)
-              {
-                std::string key;
-                knowledge::KnowledgeRecord record;
-                record.clock = clock_;
-                record.toi = checkpoint_settings.last_timestamp;
-                current = (char *)record.read (current, key, buffer_remaining);
-
-                madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-                  "ThreadSafeContext::load_context:" \
-                  " read record (%d of %d): %s\n",
-                  (int)update, (int)checkpoint_header.updates, key.c_str ());
-
-                // check if the prefix is allowed
-                if (checkpoint_settings.prefixes.size () > 0)
-                {
-                  bool prefix_found = false;
-                  for (size_t j = 0; j < checkpoint_settings.prefixes.size ()
-                                     && !prefix_found; ++j)
-                  {
-                    madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-                      "ThreadSafeContext::load_context:" \
-                      " checking record %s against prefix %s\n",
-                      key.c_str (), checkpoint_settings.prefixes[j].c_str ());
-
-                    if (madara::utility::begins_with (
-                          key, checkpoint_settings.prefixes[j]))
-                    {
-                      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-                        "ThreadSafeContext::load_context:" \
-                        " record has the correct prefix.\n");
-
-                      prefix_found = true;
-                    } // end if prefix success
-                  } // end for all prefixes
-
-                  if (!prefix_found)
-                  {
-                    madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-                      "ThreadSafeContext::load_context:" \
-                      " record does not have the correct prefix. Rejected.\n");
-
-                    continue;
-                  } // end if prefix found
-                } // end if there are prefixes in the checkpoint settings
-
-                update_record_from_external (key, record, update_settings);
-              } // end for all updates
-            } // end if state is within acceptable range
-            else
-            {
-              madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-                "ThreadSafeContext::load_context:" \
-                " not a valid state, incrementing by %d bytes.\n",
-                (int)updates_size);
-
-              current += updates_size;
-            }
-          } // end if enough buffer for reading a message header
-
-          // if (buffer_remaining == 0 && (uint64_t)total_read < meta.size)
-          // {
-          //   buffer_remaining = max_buffer;
-          //   current = buffer.get_ptr ();
-          //   total_read += fread (buffer.get_ptr (), 1, buffer_remaining, file);
-          // }
-        } // end for loop of states
-      }
-    } // end if total_read > 0
-    else
-    {
-      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
-        "ThreadSafeContext::load_context:" \
-        " invalid file. No contextual change.\n");
-    }
-
-    file.close ();
-  }
-  else
+  if (!file)
   {
     madara_logger_ptr_log (logger_, logger::LOG_ALWAYS,
       "ThreadSafeContext::load_context:" \
       " could not open file %s for reading. "
       "Check that file exists and that permissions are appropriate.\n",
       checkpoint_settings.filename.c_str ());
+    stage = 9;
+    return;
   }
 
-  return total_read;
+  max_buffer = checkpoint_settings.buffer_size;
+  buffer_remaining = max_buffer;
+
+  buffer = new char[max_buffer];
+  current = buffer.get_ptr ();
+
+  file.seekg (0, file.end);
+  int length = file.tellg();
+  file.seekg (0, file.beg);
+
+  madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+    "ThreadSafeContext::load_context:" \
+    " file contains %d bytes.\n",
+    (int)length);
+
+  if (!file.read (buffer.get (), FileHeader::encoded_size ()))
+  {
+    std::stringstream message;
+    message << "ThreadSafeContext::load_context: ";
+    message << "file ";
+    message << checkpoint_settings.filename;
+    message << " does not have enough room for an appropriate header";
+    throw exceptions::FileException (message.str ());
+  }
+  total_read = file.tellg();
+
+  buffer_remaining = (int64_t)total_read;
+
+  madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+    "ThreadSafeContext::load_context:" \
+    " reading file: %d bytes read.\n",
+    (int)total_read);
+
+  checkpoint_start = (size_t)FileHeader::encoded_size ();
+
+  if (total_read < FileHeader::encoded_size () ||
+    !FileHeader::file_header_test (current))
+  {
+    madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+      "ThreadSafeContext::load_context:" \
+      " invalid file. No contextual change.\n");
+    stage = 9;
+    return;
+  }
+
+  // if there was something in the file, and it was the right header
+
+  current = (char *)meta.read (current, buffer_remaining);
+
+  checkpoint_settings.initial_timestamp = meta.initial_timestamp;
+  checkpoint_settings.last_timestamp = meta.last_timestamp;
+  checkpoint_settings.originator = meta.originator;
+  checkpoint_settings.states = meta.states;
+  checkpoint_settings.version = utility::to_string_version (
+    meta.karl_version);
+
+  madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+            "ThreadSafeContext::load_context:" \
+            " read File meta. Meta.size=%d. Meta.states=%d\n",
+            (int)meta.size, (int)meta.states);
+
+  /**
+  * check that there is more than one state and that the rest of
+  * the file is sufficient to at least be a message header (what
+  * we use as a checkpoint header
+  **/
+  if (meta.states == 0)
+  {
+    stage = 9;
+    return;
+  }
+
+  stage = 1;
+  state = 0;
+}
+
+std::pair<std::string, KnowledgeRecord> CheckpointReader::next()
+{
+  if (stage == 0) {
+    start();
+  }
+
+  if (stage == 9) {
+    return {};
+  }
+
+  // Outer loop for progressing through stages
+  for (;;) {
+    // We're iterating to next state
+    if (stage == 1)
+    {
+      if (state >= meta.states || state > checkpoint_settings.last_state) {
+        madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+          "ThreadSafeContext::load_context:" \
+          " done at state=%d of meta.states=%d\n",
+          (int)state, (int)meta.states);
+        stage = 9;
+        return {};
+      }
+
+      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+        "ThreadSafeContext::load_context:" \
+        " reading 64bit unsigned size at %d byte file offset\n",
+        (int)checkpoint_start);
+
+      // set the file pointer to the checkpoint header start
+      //fseek (file, (long)checkpoint_start, SEEK_SET);
+      file.seekg (checkpoint_start, file.beg);
+
+      if (!file.read ((char *)&checkpoint_size, sizeof (checkpoint_size)))
+      {
+        std::stringstream message;
+        message << "ThreadSafeContext::load_context: ";
+        message << "file ";
+        message << checkpoint_settings.filename;
+        message << " does not have enough room for a checkpoint";
+        throw exceptions::FileException (message.str ());
+      }
+
+      // total_read = fread (&checkpoint_size,
+      //   1, sizeof (checkpoint_size), file);
+
+      total_read = sizeof (checkpoint_size);
+
+      checkpoint_size = utility::endian_swap (checkpoint_size);
+
+      if (checkpoint_settings.buffer_filters.size () > 0)
+      {
+        checkpoint_size += filters::BufferFilterHeader::encoded_size ();
+      }
+
+      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+        "ThreadSafeContext::load_context:" \
+        " %d state checkpoint size is %d\n",
+        (int)state, (int)checkpoint_size);
+
+      // set the file pointer to the checkpoint header start
+      file.seekg (checkpoint_start, file.beg);
+
+      checkpoint_start += checkpoint_size;
+
+      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+        "ThreadSafeContext::load_context:" \
+        " reading %d bytes for full checkpoint\n",
+        (int)checkpoint_size);
+
+      if (!file.read (buffer.get (), checkpoint_size))
+      {
+        std::stringstream message;
+        message << "ThreadSafeContext::load_context: ";
+        message << "file ";
+        message << checkpoint_settings.filename;
+        message << " does not have enough room for ";
+        message << checkpoint_size;
+        message << " bytes noted in header";
+        throw exceptions::FileException (message.str ());
+      }
+      total_read = (int64_t)checkpoint_size;
+
+      current = buffer.get_ptr ();
+
+      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+        "ThreadSafeContext::load_context:" \
+        " read %d bytes\n",
+        (int)total_read);
+
+      buffer_remaining = (int64_t)total_read;
+
+      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+        "ThreadSafeContext::load_context:" \
+        " decoding with %d buffer filters with initial size of "
+        "%d bytes and total buffer of %d bytes\n",
+        (int)checkpoint_settings.buffer_filters.size (),
+        (int)total_read, (int)max_buffer);
+
+      // call decode with any buffer filters
+      buffer_remaining = (int64_t)checkpoint_settings.decode (current,
+        (int)total_read, (int)max_buffer);
+
+      if (buffer_remaining <= 0)
+      {
+        stage = 9;
+        throw exceptions::FilterException (
+          "ThreadSafeContext::load_context: "
+          "decode () returned a negative encoding size. Bad filter/encode.");
+      }
+
+      if (buffer_remaining <= (int64_t)
+        transport::MessageHeader::static_encoded_size ())
+      {
+        stage = 9;
+        throw exceptions::MemoryException (
+          "ThreadSafeContext::load_context: "
+          "Not enough room in buffer for message header"
+        );
+      }
+
+      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+        "ThreadSafeContext::load_context:" \
+        " Reading a checkpoint header with %d byte buffer remaining\n",
+        (int)buffer_remaining);
+
+      current = (char *)checkpoint_header.read (current, buffer_remaining);
+
+      if (state == 0)
+      {
+        checkpoint_settings.initial_lamport_clock = checkpoint_header.clock;
+      }
+
+      if (state == meta.states - 1)
+      {
+        checkpoint_settings.last_lamport_clock = checkpoint_header.clock;
+      }
+
+      uint64_t updates_size = checkpoint_header.size -
+        checkpoint_header.encoded_size ();
+
+      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+          "ThreadSafeContext::load_context:" \
+          " read Checkpoint header. header.size=%d, updates.size=%d\n",
+          (int)checkpoint_header.size, (int)updates_size);
+
+      /**
+      * What we read into the checkpoint_header will dictate our
+      * max_buffer. We want to make this checkpoint_header size into
+      * something reasonable.
+      **/
+      if (updates_size > (uint64_t)buffer_remaining)
+      {
+        throw exceptions::MemoryException (
+          "ThreadSafeContext::load_context: "
+          "Not enough room in buffer for checkpoint"
+        );
+      } // end if allocation is needed
+
+      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+          "ThreadSafeContext::load_context:" \
+          " state=%d, initial_state=%d, last_state=%d\n",
+          (int)state, (int)checkpoint_settings.initial_state,
+          (int)checkpoint_settings.last_state);
+
+      if (state <= checkpoint_settings.last_state &&
+          state >= checkpoint_settings.initial_state) {
+        stage = 2;
+        update = 0;
+      } else {
+        madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+          "ThreadSafeContext::load_context:" \
+          " not a valid state, incrementing by %d bytes.\n",
+          (int)updates_size);
+
+        current += updates_size;
+      }
+      ++state;
+    }
+
+    // We're iterating to next update
+    if (stage == 2)
+    {
+      if (update >= checkpoint_header.updates) {
+        stage = 1;
+        continue;
+      }
+
+      std::string key;
+      knowledge::KnowledgeRecord record;
+      record.clock = checkpoint_header.clock;
+      record.toi = checkpoint_settings.last_timestamp;
+      current = (char *)record.read (current, key, buffer_remaining);
+
+      madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+        "ThreadSafeContext::load_context:" \
+        " read record (%d of %d): %s\n",
+        (int)update, (int)checkpoint_header.updates, key.c_str ());
+
+      // check if the prefix is allowed
+      if (checkpoint_settings.prefixes.size () > 0)
+      {
+        bool prefix_found = false;
+        for (size_t j = 0; j < checkpoint_settings.prefixes.size ()
+                           && !prefix_found; ++j)
+        {
+          madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+            "ThreadSafeContext::load_context:" \
+            " checking record %s against prefix %s\n",
+            key.c_str (), checkpoint_settings.prefixes[j].c_str ());
+
+          if (madara::utility::begins_with (
+                key, checkpoint_settings.prefixes[j]))
+          {
+            madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+              "ThreadSafeContext::load_context:" \
+              " record has the correct prefix.\n");
+
+            prefix_found = true;
+          } // end if prefix success
+        } // end for all prefixes
+
+        if (!prefix_found)
+        {
+          madara_logger_ptr_log (logger_, logger::LOG_MINOR,
+            "ThreadSafeContext::load_context:" \
+            " record does not have the correct prefix. Rejected.\n");
+
+          ++update;
+          continue;
+        } // end if prefix found
+      } // end if there are prefixes in the checkpoint settings
+
+      ++update;
+      return {key, record};
+    } // end for all updates
+  }
+}
+
+int64_t
+ThreadSafeContext::load_context (
+  CheckpointSettings & checkpoint_settings,
+  const KnowledgeUpdateSettings & update_settings)
+{
+  CheckpointReader reader(checkpoint_settings);
+
+  reader.start();
+
+  if (!reader.is_open()) {
+    return 0;
+  }
+
+  if (checkpoint_settings.clear_knowledge)
+  {
+    this->clear ();
+  }
+
+  for (;;) {
+    auto cur = reader.next();
+    if (cur.first.empty()) {
+      return reader.get_total_read();
+    }
+
+    cur.second.clock = clock_;
+    update_record_from_external (cur.first, cur.second, update_settings);
+  }
 }
 
 static uint64_t

--- a/include/madara/knowledge/ThreadSafeContext.cpp
+++ b/include/madara/knowledge/ThreadSafeContext.cpp
@@ -731,7 +731,7 @@ ThreadSafeContext::update_record_from_external (
       return -3;
 
     // if we reach this point, then the record is safe to copy
-    found->second = rhs;
+    found->second.set_full(rhs);
 
     mark_and_signal (&*found, settings);
   }
@@ -791,7 +791,7 @@ ThreadSafeContext::update_record_from_external (
       result = -3;
 
     // if we reach this point, then the record is safe to copy
-    *record = rhs;
+    record->set_full(rhs);
 
     mark_and_signal (target, settings);
   }

--- a/include/madara/knowledge/ThreadSafeContext.h
+++ b/include/madara/knowledge/ThreadSafeContext.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <map>
 #include <memory>
+#include <fstream>
 #include "madara/utility/IntTypes.h"
 
 #include "madara/MadaraExport.h"

--- a/include/madara/knowledge/ThreadSafeContext.h
+++ b/include/madara/knowledge/ThreadSafeContext.h
@@ -1941,6 +1941,77 @@ namespace madara
       /// Streaming provider for saving all updates
       std::unique_ptr<BaseStreamer> streamer_ = nullptr;
     };
+
+    /**
+     * Class for iterating binary checkpoint files
+     **/
+    class CheckpointReader
+    {
+    public:
+      /**
+       * Construct using the given CheckpointSettings. Ensure that the
+       * referenced object outlives this one.
+       **/
+      CheckpointReader(CheckpointSettings &in_checkpoint_settings)
+        : checkpoint_settings(in_checkpoint_settings),
+          logger_(logger::global_logger.get()) {}
+
+      /**
+       * Begin by reading any header information. Optional. Will be called
+       * automatically by next if need be. This opens the file specified in
+       * the settings based during construction. The file will be closed
+       * when this object is destructed.
+       **/
+      void start();
+
+      /**
+       * Get the next update from the checkpoint file. Returns an empty
+       * string and record if the end is reached.
+       **/
+      std::pair<std::string, KnowledgeRecord> next();
+
+      /**
+       * Get total number of bytes read so far during iteration.
+       **/
+      int64_t get_total_read() const { return total_read; }
+
+      /**
+       * Get the file header information. Only valid after calling start(),
+       * or next(). If not valid, returns nullptr.
+       **/
+      const FileHeader *get_file_header() const
+      {
+        if (stage == 0) {
+          return nullptr;
+        }
+
+        return &meta;
+      }
+
+      /**
+       * Check if underlying file is open. This does not imply there are more
+       * records left to read.
+       **/
+      bool is_open() const { return file.is_open(); }
+
+    private:
+      CheckpointSettings &checkpoint_settings;
+
+      logger::Logger *logger_;
+      int stage = 0;
+      std::ifstream file;
+      int64_t total_read = 0;
+      FileHeader meta;
+      int64_t max_buffer;
+      int64_t buffer_remaining;
+      utility::ScopedArray <char> buffer;
+      char * current;
+      size_t checkpoint_start;
+      uint64_t state;
+      uint64_t checkpoint_size;
+      transport::MessageHeader checkpoint_header;
+      uint64_t update;
+    };
   }
 }
 

--- a/include/madara/knowledge/ThreadSafeContext.h
+++ b/include/madara/knowledge/ThreadSafeContext.h
@@ -94,7 +94,7 @@ namespace madara
       ~ThreadSafeContext (void);
 
       /**
-       * Atomically returns the value of a variable.
+       * Atomically returns the current value of a variable.
        * @param   key       unique identifier of the variable
        * @param   settings  the settings for referring to variables
        * @return         the madara::knowledge::KnowledgeRecord::Integer value for the variable
@@ -105,13 +105,37 @@ namespace madara
                      KnowledgeReferenceSettings ()) const;
 
       /**
-       * Atomically returns the value of a variable.
+       * Atomically returns the current value of a variable.
        * @param   variable  reference to a variable (@see get_ref)
        * @param   settings  the settings for referring to variables
        * @return         the madara::knowledge::KnowledgeRecord::Integer value for the variable
        **/
       madara::knowledge::KnowledgeRecord
         get (const VariableReference & variable,
+             const KnowledgeReferenceSettings & settings =
+                     KnowledgeReferenceSettings ()) const;
+
+      /**
+       * Atomically returns the underlying value of a variable, including
+       * history. If record has no history, equivalent to get.
+       * @param   key       unique identifier of the variable
+       * @param   settings  the settings for referring to variables
+       * @return         the madara::knowledge::KnowledgeRecord::Integer value for the variable
+       **/
+      madara::knowledge::KnowledgeRecord
+        get_actual (const std::string & key,
+             const KnowledgeReferenceSettings & settings =
+                     KnowledgeReferenceSettings ()) const;
+
+      /**
+       * Atomically returns the underlying value of a variable, including
+       * history. If record has no history, equivalent to get.
+       * @param   variable  reference to a variable (@see get_ref)
+       * @param   settings  the settings for referring to variables
+       * @return         the madara::knowledge::KnowledgeRecord::Integer value for the variable
+       **/
+      madara::knowledge::KnowledgeRecord
+        get_actual (const VariableReference & variable,
              const KnowledgeReferenceSettings & settings =
                      KnowledgeReferenceSettings ()) const;
 

--- a/include/madara/knowledge/ThreadSafeContext.h
+++ b/include/madara/knowledge/ThreadSafeContext.h
@@ -1742,6 +1742,86 @@ namespace madara
        **/
       const KnowledgeMap &get_map_unsafe (void) const { return map_; }
 
+      template<typename Callable>
+      auto invoke(const std::string &key,
+          Callable &&callable,
+          const KnowledgeUpdateSettings &settings = KnowledgeUpdateSettings())
+        -> decltype(invoke_(std::forward<Callable>(callable),
+             std::declval<KnowledgeRecord &>()))
+      {
+        MADARA_GUARD_TYPE guard (mutex_);
+        auto ref = get_ref(key, settings);
+        return invoke_(std::forward<Callable>(callable),
+                       *ref.get_record_unsafe());
+      }
+
+      template<typename Callable>
+      auto invoke(const VariableReference &key,
+          Callable &&callable,
+          const KnowledgeUpdateSettings &settings = KnowledgeUpdateSettings())
+        -> decltype(invoke_(std::forward<Callable>(callable),
+             std::declval<KnowledgeRecord &>()))
+      {
+        MADARA_GUARD_TYPE guard (mutex_);
+        (void)settings;
+        return invoke_(std::forward<Callable>(callable),
+                       *key.get_record_unsafe());
+      }
+
+      template<typename Callable>
+      auto invoke(const std::string &key,
+          Callable &&callable,
+          const KnowledgeReferenceSettings &settings =
+            KnowledgeReferenceSettings())
+        const -> decltype(invoke_(std::forward<Callable>(callable),
+             std::declval<KnowledgeRecord &>()))
+      {
+        MADARA_GUARD_TYPE guard (mutex_);
+        const KnowledgeRecord *ptr = with(key, settings);
+        if (ptr) {
+          return invoke_(std::forward<Callable>(callable), *ptr);
+        }
+        const KnowledgeRecord empty;
+        return invoke_(std::forward<Callable>(callable), empty);
+      }
+
+      template<typename Callable>
+      auto invoke(const VariableReference &key,
+          Callable &&callable,
+          const KnowledgeReferenceSettings &settings =
+            KnowledgeReferenceSettings())
+        const -> decltype(invoke_(std::forward<Callable>(callable),
+             std::declval<KnowledgeRecord &>()))
+      {
+        MADARA_GUARD_TYPE guard (mutex_);
+        (void)settings;
+        return invoke_(std::forward<Callable>(callable),
+                       const_cast<const KnowledgeRecord &>(
+                         *key.get_record_unsafe()));
+      }
+
+      template<typename Callable>
+      auto cinvoke(const std::string &key,
+          Callable &&callable,
+          const KnowledgeReferenceSettings &settings =
+            KnowledgeReferenceSettings())
+        const -> decltype(invoke_(std::forward<Callable>(callable),
+             std::declval<KnowledgeRecord &>()))
+      {
+        return invoke(key, std::forward<Callable>(callable), settings);
+      }
+
+      template<typename Callable>
+      auto cinvoke(const VariableReference &key,
+          Callable &&callable,
+          const KnowledgeReferenceSettings &settings =
+            KnowledgeReferenceSettings())
+        const -> decltype(invoke_(std::forward<Callable>(callable),
+             std::declval<KnowledgeRecord &>()))
+      {
+        return invoke(key, std::forward<Callable>(callable), settings);
+      }
+
     protected:
     private:
       /**

--- a/include/madara/knowledge/ThreadSafeContext.inl
+++ b/include/madara/knowledge/ThreadSafeContext.inl
@@ -1006,6 +1006,11 @@ ThreadSafeContext::mark_and_signal (
     mark_to_checkpoint_unsafe (std::move(ref));
   }
 
+  if (settings.stream_changes && streamer_ != nullptr)
+  {
+    streamer_->enqueue(ref.get_name(), *ref.get_record_unsafe());
+  }
+
   if (settings.signal_changes)
     changed_.MADARA_CONDITION_NOTIFY_ALL ();
 }

--- a/include/madara/knowledge/ThreadSafeContext.inl
+++ b/include/madara/knowledge/ThreadSafeContext.inl
@@ -31,14 +31,45 @@ ThreadSafeContext::get (
 {
   const KnowledgeRecord *ret =  with (key, settings);
   if (ret) {
+    if (ret->has_history()) {
+      return ret->get_newest();
+    } else {
+      return *ret;
+    }
+  }
+  return KnowledgeRecord();
+}
+
+inline KnowledgeRecord
+ThreadSafeContext::get (
+  const VariableReference & variable,
+  const KnowledgeReferenceSettings & settings) const
+{
+  const KnowledgeRecord *ret =  with (variable, settings);
+  if (ret) {
+    if (ret->has_history()) {
+      return ret->get_newest();
+    } else {
+      return *ret;
+    }
+  }
+  return KnowledgeRecord();
+}
+
+inline KnowledgeRecord
+ThreadSafeContext::get_actual (
+  const std::string & key,
+  const KnowledgeReferenceSettings & settings) const
+{
+  const KnowledgeRecord *ret =  with (key, settings);
+  if (ret) {
     return *ret;
   }
   return KnowledgeRecord();
 }
 
-// return the value of a variable
 inline KnowledgeRecord
-ThreadSafeContext::get (
+ThreadSafeContext::get_actual (
   const VariableReference & variable,
   const KnowledgeReferenceSettings & settings) const
 {

--- a/include/madara/knowledge/containers/NativeCircularBufferConsumer.h
+++ b/include/madara/knowledge/containers/NativeCircularBufferConsumer.h
@@ -1,4 +1,3 @@
-
 #ifndef _MADARA_KNOWLEDGE_CONTAINERS_CIRCULARBUFFERCONSUMER_H_
 #define _MADARA_KNOWLEDGE_CONTAINERS_CIRCULARBUFFERCONSUMER_H_
 
@@ -13,8 +12,8 @@
 
 /**
  * @file NativeCircularBufferConsumer.h
- * @author James Edmondson <jedmondson@gmail.com>
  * @author David Kyle <david.kyle@shield.ai>
+ * @author James Edmondson <jedmondson@gmail.com>
  *
  * This file provides an interface similar to CircularBufferConsumer, which
  * uses the internal history buffer of KnowledgeRecord. This allows threads
@@ -34,6 +33,10 @@ namespace madara { namespace knowledge { namespace containers {
  *
  * This class uses a local index into the underlying circular buffer, and
  * is meant for one-time access of buffer elements.
+ *
+ * This class provides a subset of the capabilities of CircularBufferConsumer,
+ * as KnowledgeRecord itself provides equivalents of the rest. Use get_record()
+ * to access the KnowledgeRecord backing a NativeCircularBufferConsumer.
  */
 class MADARA_EXPORT NativeCircularBufferConsumer
 {

--- a/include/madara/knowledge/containers/NativeCircularBufferConsumer.h
+++ b/include/madara/knowledge/containers/NativeCircularBufferConsumer.h
@@ -1,0 +1,238 @@
+
+#ifndef _MADARA_KNOWLEDGE_CONTAINERS_CIRCULARBUFFERCONSUMER_H_
+#define _MADARA_KNOWLEDGE_CONTAINERS_CIRCULARBUFFERCONSUMER_H_
+
+#include <vector>
+#include <string>
+#include "madara/LockType.h"
+#include "madara/knowledge/KnowledgeBase.h"
+#include "madara/knowledge/ThreadSafeContext.h"
+#include "madara/knowledge/KnowledgeUpdateSettings.h"
+#include "Vector.h"
+#include "Integer.h"
+
+/**
+ * @file NativeCircularBufferConsumer.h
+ * @author James Edmondson <jedmondson@gmail.com>
+ * @author David Kyle <david.kyle@shield.ai>
+ *
+ * This file provides an interface similar to CircularBufferConsumer, which
+ * uses the internal history buffer of KnowledgeRecord. This allows threads
+ * sharing the same KnowledgeBase to view the same circular buffer, but this
+ * buffer is not visible to other KnowledgeBases across transports.
+ **/
+
+namespace madara { namespace knowledge { namespace containers {
+
+/**
+ * @class NativeCircularBufferConsumer
+ * @brief This class provides an interface similar to CircularBufferConsumer,
+ * which uses the internal history buffer of KnowledgeRecord. This allows
+ * threads sharing the same KnowledgeBase to view the same circular
+ * buffer, but this buffer is not visible to other KnowledgeBases across
+ * transports.
+ *
+ * This class uses a local index into the underlying circular buffer, and
+ * is meant for one-time access of buffer elements.
+ */
+class MADARA_EXPORT NativeCircularBufferConsumer
+{
+public:
+  /**
+   * Default constructor
+   **/
+  NativeCircularBufferConsumer ();
+
+  /**
+   * Constructor
+   * @param  name       name of the integer in the knowledge base
+   * @param  knowledge  the knowledge base that will contain the vector
+   * @param  settings   settings for evaluating the vector
+   * @throw exceptions::NameException  bad name ("")
+   **/
+  NativeCircularBufferConsumer (const std::string & name,
+          KnowledgeBase & knowledge);
+
+  /**
+   * Constructor
+   * @param  name      the name of the map within the variable context
+   * @param  knowledge the variable context
+   * @param  settings  settings to apply by default
+   * @throw exceptions::NameException  bad name ("")
+   **/
+  NativeCircularBufferConsumer (const std::string & name,
+          Variables & knowledge);
+
+  /**
+   * Destructor
+   **/
+  virtual ~NativeCircularBufferConsumer () = default;
+
+  /**
+   * Returns the name of the variable
+   * @return name of the variable
+   **/
+  std::string get_name (void) const;
+
+  /**
+   * Sets the variable name that this refers to
+   * @param name  the name of the variable in the knowledge base
+   * @param knowledge  the knowledge base the variable is housed in
+   * @throw exceptions::NameException  bad name ("")
+   **/
+  void set_name (const std::string & name,
+    KnowledgeBase & knowledge);
+
+  /**
+   * Sets the variable name that this refers to
+   * @param name  the name of the variable in the knowledge base
+   * @param knowledge  the knowledge base the variable is housed in
+   * @throw exceptions::NameException  bad name ("")
+   **/
+  void set_name (const std::string & name,
+    Variables & knowledge);
+
+  /**
+   * Sets the variable name that this refers to
+   * @param name  the name of the variable in the knowledge base
+   * @param knowledge  the ThreadSafeContext the variable is housed in
+   * @throw exceptions::NameException  bad name ("")
+   **/
+  void set_name (const std::string & name,
+    ThreadSafeContext & context);
+
+  /**
+   * Checks for equality
+   * @param  value  the value to compare to
+   * @return true if equal, false otherwise
+   **/
+  bool operator== (const NativeCircularBufferConsumer & value) const;
+
+  /**
+   * Checks for inequality
+   * @param  value  the value to compare to
+   * @return true if inequal, false otherwise
+   **/
+  bool operator!= (const NativeCircularBufferConsumer & value) const;
+
+  /**
+   * Consumes the record at the local index (not the producer index)
+   * @return the last added record. exists() will return false if the
+   *         record is invalid
+   * @throw exceptions::IndexException  buffer has zero size
+   **/
+  KnowledgeRecord consume (void) const;
+
+  /**
+   * Consumes the record at the local index (not the producer index)
+   * @return the last added record. exists() will return false if the
+   *         record is invalid
+   * @param  dropped the number of dropped packets. Drops can
+   *                 occur when the producer produces faster than the
+   *                 consumer can consume. This value is essentially
+   *                 index_ - local_index - size ().
+   * @throw exceptions::IndexException  buffer has zero size
+   **/
+  KnowledgeRecord consume (size_t & dropped) const;
+
+  /**
+   * Consumes the record at the local index (not the producer index)
+   * @param value  the last added value.
+   * @throw exceptions::IndexException  if no data to consume
+   **/
+  template <typename T>
+  void consume (T & value) const;
+
+  /**
+   * Consumes the record at the local index (not the producer index)
+   * @param value   the last added value.
+   * @param dropped the number of dropped packets. Drops can
+   *                occur when the producer produces faster than the
+   *                consumer can consume. This value is essentially
+   *                index_ - local_index - size ().
+   * @throw exceptions::IndexException  if no data to consume
+   **/
+  template <typename T>
+  void consume (T & value, size_t & dropped) const;
+
+  /**
+   * Returns the number of known drops since last consume
+   * @return the number of drops
+   **/
+  size_t get_dropped (void) const;
+
+  /**
+   * Returns the number of records remaining that have not been consumed.
+   * This includes records which have been dropped.
+   * @return the number of records remaining for consume
+   * @throw exceptions::ContextException  if name or context haven't
+   *                      been set appropriately
+   **/
+  size_t remaining (void) const;
+
+  /**
+   * Returns the number of records in the NativeCircularBufferConsumer
+   * @return the number of records in the NativeCircularBufferConsumer
+   * @throw exceptions::ContextException  if name or context haven't
+   *                      been set appropriately
+   **/
+  size_t count (void) const;
+
+  /**
+   * Returns the maximum size of the NativeCircularBufferConsumer
+   * @return the size of the NativeCircularBufferConsumer
+   **/
+  size_t size (void) const;
+
+  /**
+   * Resizes the buffer size to the producer's buffer size
+   **/
+  void resize (void);
+
+  /**
+   * Gets the local index.
+   * @param  index   the new index to use
+   **/
+  size_t get_index () { return local_index_; }
+
+  /**
+   * Sets the local index to an arbitrary position.
+   * @param  index   the new index to use
+   **/
+  void set_index (size_t index);
+
+  /**
+   * Get the KnowledgeRecord this container refers to. While this returns by
+   * copy, it will share the same circular buffer for read operations, but
+   * any modificatiosn will result in a copy and not be reflected in the
+   * original inside the KnowledgeBase.
+   **/
+  KnowledgeRecord get_record () const;
+
+private:
+  /**
+   * Variable context that we are modifying
+   **/
+  mutable ThreadSafeContext * context_;
+
+  /**
+   * Reference to underlying record we are reading
+   **/
+  VariableReference ref_;
+
+  /**
+   * Index for latest item read by  
+   **/
+  mutable size_t local_index_;
+
+  // Call to throw if preconditions aren't met
+  static void check_name (const char * func, const char *name);
+  void check_context (const char * func) const;
+};
+
+} } }
+
+
+#include "NativeCircularBufferConsumer.inl"
+
+#endif // _MADARA_KNOWLEDGE_CONTAINERS_CIRCULARBUFFERCONSUMER_H_

--- a/include/madara/knowledge/containers/NativeCircularBufferConsumer.inl
+++ b/include/madara/knowledge/containers/NativeCircularBufferConsumer.inl
@@ -1,0 +1,253 @@
+
+#ifndef _MADARA_KNOWLEDGE_CONTAINERS_CIRCULARBUFFERCONSUMER_INL_
+#define _MADARA_KNOWLEDGE_CONTAINERS_CIRCULARBUFFERCONSUMER_INL_
+
+#include <sstream>
+#include <math.h>
+
+#include "NativeCircularBufferConsumer.h"
+#include "madara/knowledge/ContextGuard.h"
+#include "madara/exceptions/IndexException.h"
+#include "madara/exceptions/ContextException.h"
+#include "madara/exceptions/NameException.h"
+
+namespace madara { namespace knowledge { namespace containers {
+
+inline NativeCircularBufferConsumer::NativeCircularBufferConsumer ()
+: context_ (0), local_index_ (-1)
+{
+}
+
+inline void NativeCircularBufferConsumer::check_name (const char *func,
+    const char *name)
+{
+  if (name == nullptr || name[0] == '\0') {
+    throw exceptions::NameException (
+      std::string("NativeCircularBufferConsumer::") + func + ": name is empty.");
+  }
+}
+
+inline void NativeCircularBufferConsumer::check_context (const char *func) const
+{
+  if (!context_)
+  {
+    throw exceptions::ContextException (
+      std::string("NativeCircularBufferConsumer::") + func + ": context is not set.");
+  }
+  if (!ref_.is_valid())
+  {
+    throw exceptions::ContextException (
+      std::string("NativeCircularBufferConsumer::") + func + ": underlying record is not set.");
+  }
+}
+
+inline NativeCircularBufferConsumer::NativeCircularBufferConsumer (
+  const std::string & name,
+  KnowledgeBase & knowledge)
+: context_ (&(knowledge.get_context ())), local_index_ (-1UL)
+{
+  check_name (__func__, name.c_str());
+
+  ContextGuard context_guard (knowledge);
+  set_name (name, knowledge);
+}
+ 
+inline NativeCircularBufferConsumer::NativeCircularBufferConsumer (
+  const std::string & name,
+  Variables & knowledge)
+: context_ (knowledge.get_context ()), local_index_ (-1UL)
+{
+  check_name (__func__, name.c_str());
+
+  ContextGuard context_guard (*knowledge.get_context ());
+  set_name (name, knowledge);
+}
+
+inline bool
+NativeCircularBufferConsumer::operator== (
+  const NativeCircularBufferConsumer & value) const
+{
+  return context_ == value.context_ && get_name () == value.get_name ();
+}
+
+inline bool
+NativeCircularBufferConsumer::operator!= (
+  const NativeCircularBufferConsumer & value) const
+{
+  return !operator==(value);
+}
+
+template <typename T> void
+NativeCircularBufferConsumer::consume (T & value) const
+{
+  check_context (__func__);
+
+  ContextGuard context_guard (*context_);
+
+  if (remaining () > 0)
+    value = consume ().to_any <T> ();
+  else
+    throw exceptions::IndexException ("NativeCircularBufferConsumer::consume<T>: "
+      "attempted consume on empty consumer buffer");
+}
+
+template <typename T> void
+NativeCircularBufferConsumer::consume (T & value, size_t & dropped) const
+{
+  check_context (__func__);
+
+  ContextGuard context_guard (*context_);
+
+  if (remaining () > 0)
+    value = consume (dropped).to_any <T> ();
+  else
+    throw exceptions::IndexException ("NativeCircularBufferConsumer::consume<T>: "
+      "attempted consume on empty consumer buffer");
+}
+
+inline madara::knowledge::KnowledgeRecord
+NativeCircularBufferConsumer::consume (void) const
+{
+  size_t dropped;
+  return consume(dropped);
+}
+
+inline madara::knowledge::KnowledgeRecord
+NativeCircularBufferConsumer::consume (size_t & dropped) const
+{
+  check_context (__func__);
+
+  ContextGuard context_guard (*context_);
+
+  KnowledgeRecord &rec = *ref_.get_record_unsafe();
+  size_t newest_index = rec.get_history_newest_index();
+  size_t oldest_index = rec.get_history_oldest_index();
+
+  if (local_index_ > newest_index) {
+    return KnowledgeRecord();
+  }
+
+  if (local_index_ < oldest_index) {
+    dropped = oldest_index - local_index_;
+    local_index_ = oldest_index;
+  } else {
+    dropped = 0;
+  }
+
+  KnowledgeRecord ret;
+  rec.get_history_range(&ret, local_index_, 1);
+  ++local_index_;
+  return ret;
+}
+
+inline std::string
+NativeCircularBufferConsumer::get_name (void) const
+{
+  return ref_.get_name();
+}
+
+inline size_t
+NativeCircularBufferConsumer::size (void) const
+{
+  check_context (__func__);
+
+  ContextGuard context_guard (*context_);
+
+  KnowledgeRecord &rec = *ref_.get_record_unsafe();
+  return rec.get_history_capacity ();
+}
+
+inline size_t
+NativeCircularBufferConsumer::remaining (void) const
+{
+  check_context (__func__);
+
+  ContextGuard context_guard (*context_);
+
+  KnowledgeRecord &rec = *ref_.get_record_unsafe();
+  size_t newest_index = rec.get_history_newest_index();
+  if (local_index_ > newest_index) {
+    return 0;
+  }
+  return newest_index + 1 - local_index_;
+}
+
+inline size_t
+NativeCircularBufferConsumer::count (void) const
+{
+  check_context (__func__);
+
+  ContextGuard context_guard (*context_);
+
+  KnowledgeRecord &rec = *ref_.get_record_unsafe();
+  return rec.get_history_size ();
+}
+
+inline void
+NativeCircularBufferConsumer::set_name (
+  const std::string & name, ThreadSafeContext & context)
+{
+  check_name(__func__, name.c_str());
+
+  ContextGuard context_guard (context);
+
+  context_ = &context;
+  ref_ = context_->get_ref(name);
+  local_index_ = 0;
+}
+
+inline void
+NativeCircularBufferConsumer::set_name (
+  const std::string & name, KnowledgeBase & knowledge)
+{
+  set_name (name, knowledge.get_context ());
+}
+
+inline void
+NativeCircularBufferConsumer::set_name (const std::string & name,
+  Variables & knowledge)
+{
+  set_name (name, *knowledge.get_context ());
+}
+
+
+inline void
+NativeCircularBufferConsumer::set_index (size_t index)
+{
+  check_context (__func__);
+
+  ContextGuard context_guard (*context_);
+
+  local_index_ = index;
+}
+
+inline size_t
+NativeCircularBufferConsumer::get_dropped (void) const
+{
+  check_context (__func__);
+
+  ContextGuard context_guard (*context_);
+
+  KnowledgeRecord &rec = *ref_.get_record_unsafe();
+  size_t oldest_index = rec.get_history_oldest_index();
+  if (local_index_ < oldest_index) {
+    return oldest_index - local_index_;
+  }
+  return 0;
+}
+
+inline KnowledgeRecord
+NativeCircularBufferConsumer::get_record (void) const
+{
+  check_context (__func__);
+
+  ContextGuard context_guard (*context_);
+
+  return *ref_.get_record_unsafe();
+}
+
+} // end containers namespace
+} // end knowledge namespace
+} // end madara namespace
+
+#endif //  _MADARA_KNOWLEDGE_CONTAINERS_CIRCULARBUFFERCONSUMER_INL_

--- a/include/madara/utility/CircularBuffer.h
+++ b/include/madara/utility/CircularBuffer.h
@@ -31,7 +31,7 @@ public:
       cap_(size) {}
 
   CircularBuffer(const CircularBuffer &other)
-    : CircularBuffer(other.size)
+    : CircularBuffer(other.size())
   {
     for (const T &cur : other) {
       emplace_back(cur);

--- a/include/madara/utility/CircularBuffer.h
+++ b/include/madara/utility/CircularBuffer.h
@@ -1,0 +1,438 @@
+
+
+#ifndef MADARA_KNOWLEDGE_CIRCULAR_BUFFER_H_
+#define MADARA_KNOWLEDGE_CIRCULAR_BUFFER_H_
+
+/**
+ * @file CircularBuffer.h
+ * @author David Kyle <david.kyle@shield.ai>
+ *
+ * This file contains the CircularBuffer class
+ **/
+
+#include <sstream>
+#include <memory>
+#include <type_traits>
+#include "madara/MadaraExport.h"
+#include "madara/logger/GlobalLogger.h"
+#include "madara/utility/IntTypes.h"
+#include "madara/utility/SupportTest.h"
+
+namespace madara { namespace utility {
+
+template<typename T>
+class CircularBuffer
+{
+public:
+  CircularBuffer() = default;
+
+  explicit CircularBuffer(size_t size)
+    : data_((T *)operator new(sizeof(T) * size)),
+      cap_(size) {}
+
+  CircularBuffer(const CircularBuffer &other)
+    : CircularBuffer(other.size)
+  {
+    for (const T &cur : other) {
+      emplace_back(cur);
+    }
+  }
+
+  CircularBuffer(CircularBuffer &&other) noexcept
+  {
+    swap(other);
+  }
+
+  CircularBuffer &operator=(const CircularBuffer &other)
+  {
+    CircularBuffer tmp(other);
+    *this = std::move(tmp);
+    return *this;
+  }
+
+  CircularBuffer &operator=(CircularBuffer &&other) noexcept
+  {
+    swap(other);
+    return *this;
+  }
+
+  ~CircularBuffer() noexcept
+  {
+    clear();
+    delete data_;
+  }
+
+  void swap(CircularBuffer &other) noexcept
+  {
+    using std::swap;
+    swap(front_, other.front_);
+    swap(back_, other.back_);
+    swap(data_, other.data_);
+    swap(cap_, other.cap_);
+  }
+
+  void reserve(size_t size)
+  {
+    CircularBuffer tmp(size);
+    while (!empty()) {
+      tmp.emplace_back(std::move(pop_front()));
+    }
+    swap(tmp);
+  }
+
+  bool empty() const { return front_ == back_; }
+  size_t capacity() const { return cap_; }
+  size_t size() const { return back_ - front_; }
+  size_t front_index() const { return front_; }
+  size_t back_index() const { return back_ - 1; }
+  size_t actual(size_t i) const { return i % capacity(); }
+  size_t front_actual() const { return actual(front_index()); }
+  size_t back_actual() const { return actual(back_index()); }
+
+  void clear() {
+    while (!empty()) {
+      discard_front();
+    }
+  }
+
+  class const_iterator
+  {
+  public:
+    using value_type = const T;
+    using difference_type = size_t;
+    using reference = const T &;
+    using pointer = const T *;
+    using iterator_category = std::random_access_iterator_tag;
+
+    reference operator*() const { return (*buf_)[idx_]; }
+    reference at() const { return buf_->at(idx_); }
+    pointer operator->() const { return &(*buf_)[idx_]; }
+    reference operator[](size_t i) const { return (*buf_)[idx_ + i]; }
+    reference at(size_t i) const { return buf_->at(idx_ + i); }
+    const_iterator &operator++() { ++idx_; return *this; }
+    const_iterator &operator--() { --idx_; return *this; }
+    const_iterator operator++(int) { auto ret = *this; ++idx_; return ret; }
+    const_iterator operator--(int) { auto ret = *this; --idx_; return ret; }
+    size_t index() const { return idx_; }
+    size_t index_actual() const { return buf_->actual(idx_); }
+
+    bool operator==(const const_iterator &other) const
+    {
+      return buf_ == other.buf_ && idx_ == other.idx_;
+    }
+
+    bool operator!=(const const_iterator &other) const
+    {
+      return !operator==(other);
+    }
+
+    bool operator<(const const_iterator &other) const
+    {
+      return buf_ < other.buf_ && idx_ < other.idx_;
+    }
+
+    bool operator>(const const_iterator &other) const
+    {
+      return buf_ > other.buf_ && idx_ > other.idx_;
+    }
+
+    bool operator<=(const const_iterator &other) const
+    {
+      return !operator>(other);
+    }
+
+    bool operator>=(const const_iterator &other) const
+    {
+      return !operator<(other);
+    }
+
+    const_iterator &operator+=(size_t n)
+    {
+      idx_ += n;
+      return *this;
+    }
+
+    const_iterator &operator-=(size_t n)
+    {
+      idx_ -= n;
+      return *this;
+    }
+
+    const_iterator operator+(size_t n) const
+    {
+      const_iterator ret = *this;
+      ret += n;
+      return ret;
+    }
+
+    friend const_iterator operator+(size_t n, const const_iterator &me)
+    {
+      const_iterator ret = me;
+      ret += n;
+      return ret;
+    }
+
+    const_iterator operator-(size_t n) const
+    {
+      const_iterator ret = *this;
+      ret -= n;
+      return ret;
+    }
+
+    size_t operator-(const const_iterator &other) const
+    {
+      if (buf_ != other.buf_) {
+        return (size_t) -1;
+      }
+
+      return idx_ - other.idx_;
+    }
+
+  private:
+    const_iterator(const CircularBuffer &buf, size_t idx)
+      : buf_(&buf), idx_(idx) {}
+
+    const CircularBuffer *buf_;
+    size_t idx_;
+
+    friend class CircularBuffer<T>;
+  };
+
+  class iterator
+  {
+  public:
+    using value_type = T;
+    using difference_type = size_t;
+    using reference = T &;
+    using pointer = T *;
+    using iterator_category = std::random_access_iterator_tag;
+
+    reference operator *() const { return (*buf_)[idx_]; }
+    reference at() const { return buf_->at(idx_); }
+    pointer operator ->() const { return &(*buf_)[idx_]; }
+    reference operator [](size_t i) const { return (*buf_)[idx_ + i]; }
+    reference at(size_t i) const { return buf_->at(idx_ + i); }
+    iterator &operator++() { ++idx_; return *this; }
+    iterator &operator--() { --idx_; return *this; }
+    iterator operator++(int) { auto ret = *this; ++idx_; return ret; }
+    iterator operator--(int) { auto ret = *this; --idx_; return ret; }
+    size_t index() const { return idx_; }
+    size_t index_actual() const { return buf_->actual(idx_); }
+
+    bool operator==(const iterator &other) const
+    {
+      return buf_ == other.buf_ && idx_ == other.idx_;
+    }
+
+    bool operator!=(const iterator &other) const
+    {
+      return !operator==(other);
+    }
+
+    bool operator<(const iterator &other) const
+    {
+      return buf_ < other.buf_ && idx_ < other.idx_;
+    }
+
+    bool operator>(const iterator &other) const
+    {
+      return buf_ > other.buf_ && idx_ > other.idx_;
+    }
+
+    bool operator<=(const iterator &other) const
+    {
+      return !operator>(other);
+    }
+
+    bool operator>=(const iterator &other) const
+    {
+      return !operator<(other);
+    }
+
+    iterator &operator+=(size_t n)
+    {
+      idx_ += n;
+      return *this;
+    }
+
+    iterator &operator-=(size_t n)
+    {
+      idx_ -= n;
+      return *this;
+    }
+
+    iterator operator+(size_t n) const
+    {
+      iterator ret = *this;
+      ret += n;
+      return ret;
+    }
+
+    friend iterator operator+(size_t n, const iterator &me)
+    {
+      iterator ret = me;
+      ret += n;
+      return ret;
+    }
+
+    iterator operator-(size_t n) const
+    {
+      iterator ret = *this;
+      ret -= n;
+      return ret;
+    }
+
+    size_t operator-(const iterator &other) const
+    {
+      if (buf_ != other.buf_) {
+        return (size_t) -1;
+      }
+
+      return idx_ - other.idx_;
+    }
+
+  private:
+    iterator(CircularBuffer &buf, size_t idx)
+      : buf_(&buf), idx_(idx) {}
+
+    CircularBuffer *buf_;
+    size_t idx_;
+
+    friend class CircularBuffer<T>;
+  };
+
+  iterator begin() { return {*this, front_}; }
+  iterator end() { return {*this, back_}; }
+
+  const_iterator begin() const { return {*this, front_}; }
+  const_iterator end() const { return {*this, back_}; }
+  const_iterator cbegin() const { return {*this, front_}; }
+  const_iterator cend() const { return {*this, back_}; }
+
+  T &operator[](size_t i) { return data_[actual(i)]; }
+  const T &operator[](size_t i) const { return data_[actual(i)]; }
+
+  T &front() { return (*this)[front_index()]; }
+  const T &front() const { return (*this)[front_index()]; }
+  T &back() { return (*this)[back_index()]; }
+  const T &back() const { return (*this)[back_index()]; }
+
+  T get_front() { return empty() ? T() : front(); }
+  T get_back() { return empty() ? T() : back(); }
+
+  ssize_t check_range(size_t i) const
+  {
+    ssize_t ret = i - front_;
+    if (ret < 0) {
+      return ret;
+    }
+    ret = i - back_;
+    if (ret > 0) {
+      return ret;
+    }
+    return 0;
+  }
+
+private:
+  void throw_out_of_range(const char *func, size_t i) const
+  {
+    if (i < front_)
+    {
+      std::stringstream ss;
+      ss << "CircularBuffer::" << func << ": index " << i <<
+            " is before oldest index " << front_;
+      throw std::out_of_range(ss.str());
+    }
+
+    if (i >= back_)
+    {
+      std::stringstream ss;
+      ss << "CircularBuffer::" << func << ": index " << i <<
+            " passes newest index " << back_;
+      throw std::out_of_range(ss.str());
+    }
+  }
+
+public:
+  T &at(size_t i)
+  {
+    throw_out_of_range(__func__, i);
+    return (*this)[i];
+  }
+
+  const T &at(size_t i) const
+  {
+    throw_out_of_range(__func__, i);
+    return (*this)[i];
+  }
+
+  void discard_front()
+  {
+    //std::cerr << "Discarding front: " << front_ << std::endl;
+    front().~T();
+    ++front_;
+  }
+
+  T pop_front()
+  {
+    if (empty()) {
+      return T{};
+    }
+    T ret = std::move(front());
+    discard_front();
+    return ret;
+  }
+
+  void discard_back()
+  {
+    //std::cerr << "Discarding back: " << back_ << std::endl;
+    back().~T();
+    --back_;
+  }
+
+  T pop_back()
+  {
+    if (empty()) {
+      return T{};
+    }
+    T ret = std::move(back());
+    discard_back();
+    return ret;
+  }
+
+  template<typename... Args>
+  T &emplace_back(Args&&... args)
+  {
+    if (size() >= capacity()) {
+      discard_front();
+    }
+    ++back_;
+    T &ret = *new(&(back())) T(std::forward<Args>(args)...);
+    return ret;
+  }
+
+  T &push_back(const T &val)
+  {
+    return emplace_back(val);
+  }
+
+  T &push_back(T &&val)
+  {
+    return emplace_back(std::move(val));
+  }
+
+private:
+  size_t front_ = 0;
+  size_t back_ = 0;
+
+  T *data_ = nullptr;
+
+  size_t cap_ = 0;
+
+  friend class iterator;
+  friend class const_iterator;
+};
+
+} }
+
+#endif  // _MADARA_KNOWLEDGE_CIRCULAR_BUFFER_H_

--- a/include/madara/utility/SupportTest.h
+++ b/include/madara/utility/SupportTest.h
@@ -9,6 +9,7 @@
  **/
 
 #include <type_traits>
+#include <memory>
 #include <initializer_list>
 
 /**

--- a/tests/test.h
+++ b/tests/test.h
@@ -19,7 +19,7 @@ inline void log(Args&&... args) {
    (log("INFO    : " #expr "\n"), (expr))
 
 #define VAL(expr) \
-  ([=]() mutable -> decltype(expr) { \
+  ([&]() mutable -> decltype(expr) { \
     decltype(expr) e = (expr); \
     std::ostringstream msg; \
     msg << e; \

--- a/tests/test_circular_buffer.cpp
+++ b/tests/test_circular_buffer.cpp
@@ -3,6 +3,8 @@
 
 #include "madara/utility/SupportTest.h"
 #include "madara/utility/CircularBuffer.h"
+#include "madara/knowledge/KnowledgeRecord.h"
+#include "madara/knowledge/KnowledgeBase.h"
 #include "test.h"
 
 namespace logger = madara::logger;
@@ -82,11 +84,114 @@ void test_circular_int_buffer()
   std::cout << std::endl;
 }
 
+template<typename T, typename R>
+void test_history_vector(const std::vector<R> &hist,
+    std::initializer_list<std::pair<size_t, T>> vals)
+{
+  for (const auto &cur : vals) {
+    TEST_EQ(hist[cur.first], cur.second);
+  }
+}
+
+void test_record_buffer()
+{
+  KnowledgeRecord rec;
+
+  rec.set_history_capacity(10);
+  for (int i = 1; i < 5; ++i) {
+    rec.set_value(i);
+  }
+
+  TEST_EQ(rec.get_newest(), 4);
+  TEST_EQ(rec.get_oldest().exists(), false);
+
+  for (int i = 7; i < 27; ++i) {
+    rec.set_value(i);
+  }
+
+  TEST_EQ(rec.get_newest(), 26);
+  TEST_EQ(rec.get_oldest(), 17);
+  TEST_EQ(rec.get_history(-2), 25);
+  TEST_EQ(rec.get_history(2), 19);
+
+  test_history_vector<int>(rec.get_history(),
+      {{7, 24}, {2, 19}, {4, 21}, {5, 22}});
+  test_history_vector<int>(rec.get_newest(4),
+      {{0, 23}, {3, 26}});
+  test_history_vector<std::string>(rec.get_newest<std::string>(4),
+      {{0, std::string("23")}, {3, std::string("26")}});
+  test_history_vector<const char *>(rec.get_oldest(6),
+      {{0, "17"}, {3, "20"}, {5, "22"}});
+  test_history_vector<double>(rec.get_oldest<double>(6),
+      {{0, 17}, {3, 20}, {5, 22}});
+  test_history_vector<int>(rec.get_history(3, 4),
+      {{0, 20}, {2, 22}});
+  test_history_vector<int>(rec.get_history(-5, 4),
+      {{0, 22}, {2, 24}});
+}
+
+template<typename Key>
+void test_kb(KnowledgeBase &kb, Key key)
+{
+  kb.set_history_capacity(key, 10);
+  for (int i = 1; i < 5; ++i) {
+    kb.set(key, i);
+  }
+
+  TEST_EQ(kb.get_newest(key), 4);
+  TEST_EQ(kb.get_oldest(key).exists(), false);
+
+  for (int i = 7; i < 27; ++i) {
+    kb.set(key, i);
+  }
+
+  TEST_EQ(kb.get_newest(key), 26);
+  TEST_EQ(kb.get_oldest(key), 17);
+  TEST_EQ(kb.get_history(key, -2), 25);
+  TEST_EQ(kb.get_history(key, 2), 19);
+
+  test_history_vector<int>(kb.get_history(key),
+      {{7, 24}, {2, 19}, {4, 21}, {5, 22}});
+  test_history_vector<int>(kb.get_newest(key, 4),
+      {{0, 23}, {3, 26}});
+  test_history_vector<std::string>(kb.get_newest<std::string>(key, 4),
+      {{0, std::string("23")}, {3, std::string("26")}});
+  test_history_vector<const char *>(kb.get_oldest(key, 6),
+      {{0, "17"}, {3, "20"}, {5, "22"}});
+  test_history_vector<double>(kb.get_oldest<double>(key, 6),
+      {{0, 17}, {3, 20}, {5, 22}});
+  test_history_vector<int>(kb.get_history(key, 3, 4),
+      {{0, 20}, {2, 22}});
+  test_history_vector<int>(kb.get_history(key, -5, 4),
+      {{0, 22}, {2, 24}});
+}
+
 int main (int, char **)
 {
   madara::logger::global_logger->set_level(9);
 
+  std::cerr << "Test CircularBuffer directly" << std::endl;
   test_circular_int_buffer();
+
+  std::cerr << "Test KnowledgeRecord with history" << std::endl;
+  test_record_buffer();
+
+  std::cerr << "Test KnowledgeBase record with string index" << std::endl;
+  {
+    std::string key = "test";
+    KnowledgeBase kb;
+
+    test_kb(kb, key);
+  }
+
+  std::cerr << "Test KnowledgeBase record with VariableReference" << std::endl;
+  {
+    std::string key = "test";
+    KnowledgeBase kb;
+    auto ref = kb.get_ref(key);
+
+    test_kb(kb, ref);
+  }
 
   if (madara_tests_fail_count > 0)
   {

--- a/tests/test_circular_buffer.cpp
+++ b/tests/test_circular_buffer.cpp
@@ -1,0 +1,102 @@
+#include <string>
+#include <iostream>
+
+#include "madara/utility/SupportTest.h"
+#include "madara/utility/CircularBuffer.h"
+#include "test.h"
+
+namespace logger = madara::logger;
+
+using namespace madara;
+using namespace knowledge;
+using namespace utility;
+
+template<typename T>
+std::ostream &operator<<(std::ostream &o, const CircularBuffer<T> &buf)
+{
+  for (const auto &cur : buf) {
+    o << cur << " ";
+  }
+  return o;
+}
+
+void test_circular_int_buffer()
+{
+  CircularBuffer<int> b(10);
+
+  VAL(b.capacity());
+
+  for (int i = 0; i < 5; ++i) {
+    VAL(b.size());
+    b.push_back(i);
+  }
+
+  std::cout << b << std::endl;
+
+  for (int i = 5; i < 10; ++i) {
+    VAL(b.size());
+    b.push_back(i);
+  }
+
+  std::cout << b << std::endl;
+
+  b.push_back(10);
+
+  std::cout << b << std::endl;
+
+  b.push_back(11);
+
+  std::cout << b << std::endl;
+
+  b.push_back(12);
+
+  std::cout << b << std::endl;
+
+  b.pop_front();
+  b.pop_front();
+
+  std::cout << b << std::endl;
+
+  b.push_back(13);
+
+  std::cout << b << std::endl;
+
+  b.push_back(14);
+
+  std::cout << b << std::endl;
+
+  b.pop_back();
+  b.pop_back();
+
+  std::cout << b << std::endl;
+
+  b.push_back(15);
+
+  std::cout << b << std::endl;
+
+  for (auto iter = std::reverse_iterator<typename CircularBuffer<int>::iterator>(b.end());
+      iter != std::reverse_iterator<typename CircularBuffer<int>::iterator>(b.begin()); ++iter)
+  {
+    std::cout << *iter << std::endl;
+  }
+  std::cout << std::endl;
+}
+
+int main (int, char **)
+{
+  madara::logger::global_logger->set_level(9);
+
+  test_circular_int_buffer();
+
+  if (madara_tests_fail_count > 0)
+  {
+    std::cerr << "OVERALL: FAIL. " << madara_tests_fail_count <<
+      " tests failed.\n";
+  }
+  else
+  {
+    std::cerr << "OVERALL: SUCCESS.\n";
+  }
+
+  return madara_tests_fail_count;
+}

--- a/tests/test_system_calls.cpp
+++ b/tests/test_system_calls.cpp
@@ -35,7 +35,7 @@ int main (int argc, char * argv[])
 
   if (
     knowledge.get ("sample").type () == 
-       (int32_t) knowledge.get ("sample.type").to_integer () &&
+       (uint32_t) knowledge.get ("sample.type").to_integer () &&
     knowledge.get ("sample").size () == 
        (uint32_t) knowledge.get ("sample.size").to_integer () &&
     knowledge.get ("sample.clock").to_string () == "20" &&


### PR DESCRIPTION
Implementation of circular buffering inside the KnowledgeBase, and checkpoing streaming. A few things we've discussed this does NOT implement include:

* Support for a central manifest setting history capacities of records. This feature should be discussed further before implementation, I think. Currently, history capacity can be set with `KnowledgeBase::set_history_capacity()` with a string key or `VariableReference`.

* No playback over time is implemented yet. An iterator reader for checkpoints is available which should make implementing this straightforward.