### PR TITLE
Upgrade NativeCircularBufferConsumer to match functionality of CircularBufferConsumer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -171,6 +171,7 @@ script:
   - $MADARA_ROOT/bin/test_rcw_transaction
   - $MADARA_ROOT/bin/test_rcw_prodcon
   - $MADARA_ROOT/bin/test_rcw_custom
+  - $MADARA_ROOT/bin/test_threader_change_hertz
   - $MADARA_ROOT/bin/test_knowledge_record
   - $MADARA_ROOT/bin/test_knowledge_base
   # performance test (useful to see if we've regressed in performance)

--- a/include/madara/knowledge/containers/NativeCircularBufferConsumer.h
+++ b/include/madara/knowledge/containers/NativeCircularBufferConsumer.h
@@ -1,5 +1,5 @@
-#ifndef _MADARA_KNOWLEDGE_CONTAINERS_CIRCULARBUFFERCONSUMER_H_
-#define _MADARA_KNOWLEDGE_CONTAINERS_CIRCULARBUFFERCONSUMER_H_
+#ifndef _MADARA_KNOWLEDGE_CONTAINERS_NATIVECIRCULARBUFFERCONSUMER_H_
+#define _MADARA_KNOWLEDGE_CONTAINERS_NATIVECIRCULARBUFFERCONSUMER_H_
 
 #include <vector>
 #include <string>
@@ -183,7 +183,7 @@ public:
 
   /**
    * Returns the maximum size of the NativeCircularBufferConsumer
-   * @return the size of the NativeCircularBufferConsumer
+    * @return the size of the NativeCircularBufferConsumer
    **/
   size_t size (void) const;
 
@@ -212,6 +212,19 @@ public:
    **/
   KnowledgeRecord get_record () const;
 
+  template <typename T> void consume_earliest (size_t count,std::vector <T> & values) const;
+
+  std::vector <KnowledgeRecord> consume_earliest (size_t count) const;
+
+  template <typename T> void inspect (KnowledgeRecord::Integer position, T & value) const;
+
+  std::vector <KnowledgeRecord> inspect (KnowledgeRecord::Integer position,size_t count) const;
+
+  template <typename T> void inspect (KnowledgeRecord::Integer position,
+                                      size_t count, std::vector <T> & values) const;
+
+  madara::knowledge::KnowledgeRecord inspect (KnowledgeRecord::Integer position) const;
+
 private:
   /**
    * Variable context that we are modifying
@@ -238,4 +251,4 @@ private:
 
 #include "NativeCircularBufferConsumer.inl"
 
-#endif // _MADARA_KNOWLEDGE_CONTAINERS_CIRCULARBUFFERCONSUMER_H_
+#endif // _MADARA_KNOWLEDGE_CONTAINERS_NATIVECIRCULARBUFFERCONSUMER_H_

--- a/include/madara/logger/Logger.cpp
+++ b/include/madara/logger/Logger.cpp
@@ -4,7 +4,7 @@
 #include <time.h>
 #include <madara/utility/Utility.h>
 #include <boost/lexical_cast.hpp>
-
+#include <iomanip>
 
 thread_local int madara::logger::Logger::thread_level_(madara::logger::TLS_THREAD_LEVEL_DEFAULT);
 thread_local std::string madara::logger::Logger::thread_name_("");
@@ -45,7 +45,8 @@ madara::logger::Logger::search_and_insert_custom_tstamp(const std::string & buf,
   std::size_t found = 0;
   std::size_t offset = 0;
   std::string retstring = buf;
-  
+  const int MGT_DIGIT_PRECISION = 6;
+
   while ( !done )
   {
     found = retstring.find(tsstr.c_str(),found+offset,tsstr.length());
@@ -63,8 +64,10 @@ madara::logger::Logger::search_and_insert_custom_tstamp(const std::string & buf,
       double mgt_time = madara::utility::get_time () / (double)1000000000;
 
       //insert this value into the buffer
-      std::string mgtstr = boost::lexical_cast<std::string>(mgt_time);
-      retstring.replace(retstring.find(tsstr),tsstr.length(),mgtstr);
+      std::stringstream mgtstr;
+      
+      mgtstr << std::setprecision(MGT_DIGIT_PRECISION) << std::fixed << mgt_time;
+      retstring.replace(retstring.find(tsstr),tsstr.length(),mgtstr.str());
       continue;
     }else
     if ( tsstr == MADARA_THREAD_NAME )

--- a/include/madara/logger/Logger.cpp
+++ b/include/madara/logger/Logger.cpp
@@ -6,15 +6,16 @@
 #include <boost/lexical_cast.hpp>
 
 
-thread_local std::atomic<int> thread_level_(madara::logger::TLS_THREAD_LEVEL_DEFAULT);
-thread_local std::string thread_name_;
-thread_local std::atomic<double> thread_hertz_(madara::logger::TLS_THREAD_HZ_DEFAULT);
+thread_local int madara::logger::Logger::thread_level_(madara::logger::TLS_THREAD_LEVEL_DEFAULT);
+thread_local std::string madara::logger::Logger::thread_name_("");
+thread_local double madara::logger::Logger::thread_hertz_(madara::logger::TLS_THREAD_HZ_DEFAULT);
 
 madara::logger::Logger::Logger (bool log_to_terminal)
 : mutex_ (), level_ (LOG_ERROR),
   term_added_ (log_to_terminal), syslog_added_ (false), tag_ ("madara"),
   timestamp_format_ ("")
 {
+  
   if (log_to_terminal)
   {
     add_term ();
@@ -27,35 +28,6 @@ madara::logger::Logger::~Logger ()
 }
 
 
-int madara::logger::Logger::get_thread_level(void)
-{
-  return thread_level_;
-}
-
-std::string madara::logger::Logger::get_thread_name(void)
-{
-  return thread_name_;
-}
-
-double madara::logger::Logger::get_thread_hertz(void)
-{
-  return thread_hertz_;
-}
-
-void madara::logger::Logger::set_thread_level(int level)
-{
-  thread_level_ = level;
-}
-
-void madara::logger::Logger::set_thread_name(const std::string name)
-{
-  thread_name_ = name;
-}
-
-void madara::logger::Logger::set_thread_hertz(double hertz)
-{
-  thread_hertz_ = hertz;
-}
 
 std::string
 madara::logger::Logger::strip_custom_tstamp(const std::string instr,const std::string tsstr)
@@ -72,7 +44,7 @@ madara::logger::Logger::search_and_insert_custom_tstamp(const std::string & buf,
   bool done = false;
   std::size_t found = 0;
   std::size_t offset = 0;
-  std::string retstring(buf);
+  std::string retstring = buf;
   
   while ( !done )
   {
@@ -80,7 +52,7 @@ madara::logger::Logger::search_and_insert_custom_tstamp(const std::string & buf,
     if ( found == std::string::npos )
     {
       done = true;
-      break;
+      continue;
     }
 
     offset = 1;
@@ -88,7 +60,8 @@ madara::logger::Logger::search_and_insert_custom_tstamp(const std::string & buf,
     {
       // insert mgt text here
       //get_time returns nsecs. need to convert into seconds.
-      int64_t mgt_time = (madara::utility::get_time () / (int64_t)100000) / (int64_t)1000000;
+      int64_t mgt_time = (madara::utility::get_time () / (int64_t)100000) / (int64_t)10000;
+
       //insert this value into the buffer
       std::string mgtstr = boost::lexical_cast<std::string>(mgt_time);
       retstring.replace(retstring.find(tsstr),tsstr.length(),mgtstr);
@@ -129,33 +102,6 @@ madara::logger::Logger::log (int level, const char * message, ...)
 
     if (this->timestamp_format_.size () > 0)
     {
-      std::string madstr(buffer);
-      std::string tmpstr;
-
-      tmpstr = search_and_insert_custom_tstamp(madstr,MADARA_GET_TIME_MGT);
-      if ( tmpstr.length() > remaining_buffer )
-      {
-        madstr = strip_custom_tstamp(madstr,MADARA_GET_TIME_MGT);
-        madstr.copy(begin,madstr.length());
-      }else
-        madstr = tmpstr;
-
-      tmpstr = search_and_insert_custom_tstamp(madstr,MADARA_THREAD_NAME);
-      if ( tmpstr.length() > remaining_buffer )
-      {
-        madstr = strip_custom_tstamp(madstr,MADARA_THREAD_NAME);
-        madstr.copy(begin,madstr.length());
-      }else
-        madstr = tmpstr;
-
-      tmpstr = search_and_insert_custom_tstamp(madstr,MADARA_THREAD_HERTZ);
-      if ( madstr.length() > remaining_buffer )
-      {
-        madstr = strip_custom_tstamp(madstr,MADARA_THREAD_HERTZ);
-        madstr.copy(begin,madstr.length());
-      }else
-        madstr = tmpstr;
-
       time_t rawtime;
       struct tm * timeinfo;
 
@@ -169,7 +115,15 @@ madara::logger::Logger::log (int level, const char * message, ...)
       begin += chars_written;
     }
 
-    vsnprintf (begin, remaining_buffer, message, argptr);
+    std::string madstr = message;
+    madstr = search_and_insert_custom_tstamp(madstr,MADARA_GET_TIME_MGT);
+    madstr = search_and_insert_custom_tstamp(madstr,MADARA_THREAD_NAME);
+    madstr = search_and_insert_custom_tstamp(madstr,MADARA_THREAD_HERTZ);
+    
+    char custom_buffer[10240];
+    std::strcpy(custom_buffer, madstr.c_str());
+
+    vsnprintf (begin, remaining_buffer, custom_buffer, argptr);
 
     va_end (argptr);
 

--- a/include/madara/logger/Logger.cpp
+++ b/include/madara/logger/Logger.cpp
@@ -60,7 +60,7 @@ madara::logger::Logger::search_and_insert_custom_tstamp(const std::string & buf,
     {
       // insert mgt text here
       //get_time returns nsecs. need to convert into seconds.
-      int64_t mgt_time = (madara::utility::get_time () / (int64_t)100000) / (int64_t)10000;
+      double mgt_time = madara::utility::get_time () / (double)1000000000;
 
       //insert this value into the buffer
       std::string mgtstr = boost::lexical_cast<std::string>(mgt_time);

--- a/include/madara/logger/Logger.cpp
+++ b/include/madara/logger/Logger.cpp
@@ -102,28 +102,32 @@ madara::logger::Logger::log (int level, const char * message, ...)
 
     if (this->timestamp_format_.size () > 0)
     {
+      std::string madstr = message;
+      madstr = search_and_insert_custom_tstamp(madstr,MADARA_GET_TIME_MGT);
+      madstr = search_and_insert_custom_tstamp(madstr,MADARA_THREAD_NAME);
+      madstr = search_and_insert_custom_tstamp(madstr,MADARA_THREAD_HERTZ);
+    
+      char custom_buffer[10240];
+      std::strcpy(custom_buffer, madstr.c_str());
+
       time_t rawtime;
       struct tm * timeinfo;
 
       time (&rawtime);
       timeinfo = localtime (&rawtime);
 
+      madstr = search_and_insert_custom_tstamp(timestamp_format_,MADARA_GET_TIME_MGT);
+      madstr = search_and_insert_custom_tstamp(madstr,MADARA_THREAD_NAME);
+      madstr = search_and_insert_custom_tstamp(madstr,MADARA_THREAD_HERTZ);
+      
       size_t chars_written = strftime (
-        begin, remaining_buffer, timestamp_format_.c_str (), timeinfo);
+        begin, remaining_buffer, madstr.c_str (), timeinfo);
 
       remaining_buffer -= chars_written;
       begin += chars_written;
-    }
-
-    std::string madstr = message;
-    madstr = search_and_insert_custom_tstamp(madstr,MADARA_GET_TIME_MGT);
-    madstr = search_and_insert_custom_tstamp(madstr,MADARA_THREAD_NAME);
-    madstr = search_and_insert_custom_tstamp(madstr,MADARA_THREAD_HERTZ);
-    
-    char custom_buffer[10240];
-    std::strcpy(custom_buffer, madstr.c_str());
-
-    vsnprintf (begin, remaining_buffer, custom_buffer, argptr);
+      vsnprintf (begin, remaining_buffer, custom_buffer, argptr);
+    }else
+      vsnprintf (begin, remaining_buffer, message, argptr);
 
     va_end (argptr);
 

--- a/include/madara/logger/Logger.inl
+++ b/include/madara/logger/Logger.inl
@@ -9,7 +9,6 @@
 #include <android/log.h>
 #endif
 
-
 inline void
 madara::logger::Logger::add_file (const std::string & filename)
 {
@@ -111,5 +110,6 @@ madara::logger::Logger::set_timestamp_format (const std::string & format)
 
   this->timestamp_format_ = format;
 }
+
 
 #endif // _MADARA_LOGGER_LOGGER_INL_

--- a/include/madara/logger/Logger.inl
+++ b/include/madara/logger/Logger.inl
@@ -53,6 +53,42 @@ madara::logger::Logger::get_tag (void)
   return tag_;
 }
 
+inline int 
+madara::logger::Logger::get_thread_level(void)
+{
+  return thread_level_;
+}
+
+inline std::string 
+madara::logger::Logger::get_thread_name(void)
+{
+  return thread_name_;
+}
+
+inline double 
+madara::logger::Logger::get_thread_hertz(void)
+{
+  return thread_hertz_;
+}
+
+inline void 
+madara::logger::Logger::set_thread_level(int level)
+{
+  thread_level_ = level;
+}
+
+inline void 
+madara::logger::Logger::set_thread_name(const std::string name)
+{
+  thread_name_ = name;
+}
+
+inline void
+madara::logger::Logger::set_thread_hertz(double hertz)
+{
+  thread_hertz_ = hertz;
+}
+
 inline void
 madara::logger::Logger::set_tag (const std::string & tag)
 {

--- a/include/madara/threads/WorkerThread.cpp
+++ b/include/madara/threads/WorkerThread.cpp
@@ -137,10 +137,12 @@ WorkerThread::svc (void)
 
       terminated = control_.get_ref (name_ + ".terminated");
       paused = control_.get_ref (name_ + ".paused");
+      madara::logger::Logger::set_thread_name(name_);
 
       // change thread frequency
       change_frequency (hertz_, current, frequency, next_epoch,
         one_shot, blaster);
+      madara::logger::Logger::set_thread_hertz(hertz_);
 
       while (control_.get (terminated).is_false ())
       {

--- a/include/madara/threads/WorkerThread.inl
+++ b/include/madara/threads/WorkerThread.inl
@@ -20,6 +20,7 @@ WorkerThread::change_frequency (
   bool & one_shot, bool & blaster)
 {
   hertz_ = hertz;
+  madara::logger::Logger::set_thread_hertz(hertz);
   if (hertz_ > 0.0)
   {
     madara_logger_ptr_log (logger::global_logger.get (), logger::LOG_MAJOR,

--- a/tests/threads/test_threader_change_hertz.cpp
+++ b/tests/threads/test_threader_change_hertz.cpp
@@ -176,6 +176,8 @@ int main (int argc, char ** argv)
   // handle all user arguments
   handle_arguments (argc, argv);
   
+  logger::global_logger.get()->set_timestamp_format();
+
   // create a knowledge base and setup our id
   knowledge::KnowledgeBase knowledge;
 
@@ -186,7 +188,15 @@ int main (int argc, char ** argv)
     "Target is set to %ll\n",
     hertz, second_hertz, counters, target);
 
-  // create a counter
+  madara_logger_ptr_log (logger::global_logger.get(), logger::LOG_ALWAYS,
+                         "MGT: %MGT\n");
+
+    madara_logger_ptr_log (logger::global_logger.get(), logger::LOG_ALWAYS,
+                           "MTN: %MTN\n");
+
+    madara_logger_ptr_log (logger::global_logger.get(), logger::LOG_ALWAYS,
+                           "MTZ: %MTZ\n");
+// create a counter
   containers::Integer counter ("counter", knowledge);
 
   // create a threader for running threads

--- a/tests/threads/test_threader_change_hertz.cpp
+++ b/tests/threads/test_threader_change_hertz.cpp
@@ -163,6 +163,18 @@ public:
   {
     ++counter;
     data.print (message);
+    int rnd = std::rand() % 19 + (-9);
+    int logger_rnd = std::rand() % 3 + (-1);
+    
+    madara::logger::Logger::set_thread_level(logger_rnd);
+    madara_logger_ptr_log (logger::global_logger.get(), rnd,//logger::LOG_ALWAYS,
+                           "CounterThread::Run MGT: %MGT  rnd=%d lrnd=%d\n",rnd,logger_rnd);
+
+    madara_logger_ptr_log (logger::global_logger.get(), rnd,//logger::LOG_ALWAYS,
+                           "CounterThread::Run MTN: %MTN rnd=%d lrnd=%d\n",rnd,logger_rnd);
+
+    madara_logger_ptr_log (logger::global_logger.get(), rnd,//logger::LOG_ALWAYS,
+                           "CounterThread::Run MTZ: %MTZ rnd=%d lrnd=%d\n",rnd,logger_rnd);
   }
 
 private:
@@ -191,11 +203,11 @@ int main (int argc, char ** argv)
   madara_logger_ptr_log (logger::global_logger.get(), logger::LOG_ALWAYS,
                          "MGT: %MGT\n");
 
-    madara_logger_ptr_log (logger::global_logger.get(), logger::LOG_ALWAYS,
-                           "MTN: %MTN\n");
+  madara_logger_ptr_log (logger::global_logger.get(), logger::LOG_ALWAYS,
+                         "MTN: %MTN\n");
 
-    madara_logger_ptr_log (logger::global_logger.get(), logger::LOG_ALWAYS,
-                           "MTZ: %MTZ\n");
+  madara_logger_ptr_log (logger::global_logger.get(), logger::LOG_ALWAYS,
+                         "MTZ: %MTZ\n");
 // create a counter
   containers::Integer counter ("counter", knowledge);
 

--- a/tests/threads/test_threader_change_hertz.cpp
+++ b/tests/threads/test_threader_change_hertz.cpp
@@ -176,7 +176,7 @@ int main (int argc, char ** argv)
   // handle all user arguments
   handle_arguments (argc, argv);
   
-  logger::global_logger.get()->set_timestamp_format();
+  logger::global_logger.get()->set_timestamp_format("%x %X %MTZ %MGT (%MTN): ");
 
   // create a knowledge base and setup our id
   knowledge::KnowledgeBase knowledge;


### PR DESCRIPTION
This is to reimplement some methods from CBC, and data_buffer.h + data_buffer_test into NCBC.  The idea is not to port but to provide similar method interfaces for NCBC contextl.
