### PR TITLE
Selective run Java maven tests

### DIFF
--- a/port/java/pom.xml
+++ b/port/java/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ai.madara</groupId>
 	<artifactId>madara</artifactId>
-	<version>3.2.4</version>
+	<version>3.3.0</version>
 	<description>Provides distributed knowledge sharing services for multi-agent systems.</description>
 	<name>Multi-Agent Distributed Adaptive Resource Allocation</name>
 	<url>http://madara.ai</url>

--- a/port/java/src/test/java/ai/madara/tests/basic/ContainerTest.java
+++ b/port/java/src/test/java/ai/madara/tests/basic/ContainerTest.java
@@ -45,7 +45,7 @@
  * @author James Edmondson <jedmondson@gmail.com>
  *********************************************************************/
 
-package ai.madara.tests;
+package ai.madara.tests.basic;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -66,6 +66,7 @@ import ai.madara.knowledge.containers.NativeDoubleVector;
 import ai.madara.knowledge.containers.Queue;
 import ai.madara.knowledge.containers.StringVector;
 import ai.madara.knowledge.containers.Vector;
+import ai.madara.tests.BaseTest;
 
 /**
  * This class is a tester for the ai.madara.knowledge.containers package

--- a/port/java/src/test/java/ai/madara/tests/basic/TestAny.java
+++ b/port/java/src/test/java/ai/madara/tests/basic/TestAny.java
@@ -45,75 +45,71 @@
  * @author David Kyle <david.kyle@shield.ai>
  *********************************************************************/
 
-package ai.madara.tests;
-
-import ai.madara.knowledge.Any;
-import ai.madara.knowledge.AnyRef;
-import ai.madara.knowledge.KnowledgeRecord;
-import ai.madara.knowledge.KnowledgeBase;
+package ai.madara.tests.basic;
 
 import org.capnproto.MessageBuilder;
-import org.capnproto.StructBuilder;
-import org.capnproto.StructReader;
+import org.junit.Assert;
+import org.junit.Test;
+
+import ai.madara.knowledge.Any;
+import ai.madara.tests.BaseTest;
 import ai.madara.tests.capnp.Geo;
 
 /**
  * This class is a tester for Any and AnyRef
  */
-public class TestAny {
-  public static void main (java.lang.String...args) throws InterruptedException, Exception
-  {
-    System.err.println("Loading libMADARA.so");
-    System.loadLibrary("MADARA");
+public class TestAny extends BaseTest {
+	@Test
+	public void testAny() throws InterruptedException, Exception {
 
-    //System.err.println("Loading libdatatypes_shared.so");
-    //System.loadLibrary("datatypes_shared");
+		// System.err.println("Loading libdatatypes_shared.so");
+		// System.loadLibrary("datatypes_shared");
 
-    KnowledgeBase kb = new KnowledgeBase();
+		Any.registerStringVector("strvec");
+		Any.registerDoubleVector("dblvec");
+		Any.registerStringToStringMap("smap");
 
-    Any.registerStringVector("strvec");
-    Any.registerDoubleVector("dblvec");
-    Any.registerStringToStringMap("smap");
+		Any.registerClass("Point", Geo.Point.factory);
 
-    Any.registerClass("Point", Geo.Point.factory);
+		Any a0 = new Any("smap");
+		a0.at("hello").assign("world");
 
-    Any a0 = new Any("smap");
-    a0.at("hello").assign("world");
+		Assert.assertEquals(a0.at("hello").toString(), "world");
 
-    System.err.println("a0[hello] = " + a0.at("hello"));
+		Any a1 = new Any("strvec");
+		a1.at(5).assign("fifth");
+		a1.at(7).assign("seventh");
+		a1.at(2).assign("second");
 
-    Any a1 = new Any("strvec");
-    a1.at(5).assign("fifth");
-    a1.at(7).assign("seventh");
-    a1.at(2).assign("second");
+		for (long i = 0, n = a1.size(); i < n; ++i) {
+			System.err.println("a1[" + i + "] = " + a1.at(i));
+		}
 
-    for (long i = 0, n = a1.size(); i < n; ++i) {
-      System.err.println("a1[" + i + "] = " + a1.at(i));
-    }
+		Assert.assertFalse(a1.at(0).empty());
+		Assert.assertNotNull(a1.at(2));
+		Assert.assertEquals(a1.at(2).toString(), "second");
+		/*
+		 * Any p0 = new Any("Point"); System.err.println("p0 = " + p0);
+		 * 
+		 * Any p1 = new Any("Pose"); System.err.println("p1 = " + p1);
+		 * 
+		 * kb.set("p0", p0); kb.set("p1", p1);
+		 * 
+		 * System.err.println("kb.p0 = " + kb.get("p0")); System.err.println("kb.p1 = "
+		 * + kb.get("p1"));
+		 */
 
-    /*Any p0 = new Any("Point");
-    System.err.println("p0 = " + p0);
+		MessageBuilder msg = new MessageBuilder();
+		Geo.Point.Builder builder = msg.initRoot(Geo.Point.factory);
+		builder.setX(12);
+		builder.setY(32);
+		builder.setZ(47);
+		Any c0 = new Any(Geo.Point.factory, msg);
 
-    Any p1 = new Any("Pose");
-    System.err.println("p1 = " + p1);
+		Geo.Point.Reader reader = c0.reader(Geo.Point.factory);
+		Assert.assertEquals(reader.getX(), 12, 0.0);
+		Assert.assertEquals(reader.getY(), 32, 0.01);
+		Assert.assertEquals(reader.getZ(), 47, 0);
 
-    kb.set("p0", p0);
-    kb.set("p1", p1);
-
-    System.err.println("kb.p0 = " + kb.get("p0"));
-    System.err.println("kb.p1 = " + kb.get("p1"));*/
-
-    MessageBuilder msg = new MessageBuilder();
-    Geo.Point.Builder builder = msg.initRoot(Geo.Point.factory);
-    builder.setX(12);
-    builder.setY(32);
-    builder.setZ(47);
-    Any c0 = new Any(Geo.Point.factory, msg);
-    System.err.println("c0 = " + c0);
-
-    Geo.Point.Reader reader = c0.reader(Geo.Point.factory);
-    System.err.println("c0.x = " + reader.getX());
-    System.err.println("c0.y = " + reader.getY());
-    System.err.println("c0.z = " + reader.getZ());
-  }
+	}
 }

--- a/port/java/src/test/java/ai/madara/tests/basic/TestKnowledgeBase.java
+++ b/port/java/src/test/java/ai/madara/tests/basic/TestKnowledgeBase.java
@@ -45,7 +45,7 @@
  * @author James Edmondson <jedmondson@gmail.com>
  *********************************************************************/
 
-package ai.madara.tests;
+package ai.madara.tests.basic;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -55,6 +55,7 @@ import ai.madara.knowledge.KnowledgeBase;
 import ai.madara.knowledge.KnowledgeMap;
 import ai.madara.knowledge.containers.Integer;
 import ai.madara.knowledge.containers.String;
+import ai.madara.tests.BaseTest;
 
 /**
  * This class is a tester for basic KnowledgeBase functionality

--- a/port/java/src/test/java/ai/madara/tests/lz4/LZ4BufferFilterTest.java
+++ b/port/java/src/test/java/ai/madara/tests/lz4/LZ4BufferFilterTest.java
@@ -45,7 +45,7 @@
  * @author James Edmondson <jedmondson@gmail.com>
  *********************************************************************/
 
-package ai.madara.tests;
+package ai.madara.tests.lz4;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -95,6 +95,7 @@ public class LZ4BufferFilterTest {
 		Assert.assertNotEquals(encoded, decoded);
 		Assert.assertEquals(decoded, plaintext);
 
+		
 	}
 
 }

--- a/port/java/src/test/java/ai/madara/tests/ssl/AesBufferFilterTest.java
+++ b/port/java/src/test/java/ai/madara/tests/ssl/AesBufferFilterTest.java
@@ -45,7 +45,7 @@
  * @author James Edmondson <jedmondson@gmail.com>
  *********************************************************************/
 
-package ai.madara.tests;
+package ai.madara.tests.ssl;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -97,6 +97,7 @@ public class AesBufferFilterTest {
 		Assert.assertNotEquals(encoded, decoded);
 		Assert.assertEquals(decoded, plaintext);
 
+		
 	}
 
 }

--- a/port/java/using_java.mpb
+++ b/port/java/using_java.mpb
@@ -7,10 +7,8 @@ feature (java) {
   
   macros += _MADARA_JAVA_
 
-  postbuild += mvn -f port/java versions:set -DnewVersion=`<%cat%> $(MADARA_ROOT)/VERSION.txt`
-  postbuild += mvn -f port/java versions:commit
-  postbuild += mvn -f port/java -DskipTests -P development clean package install
-
+  
+ 
   Define_Custom (JAVA_CAPN) {
     command = capnp compile -I $(CAPNP_ROOT)/c++/src -ojava
     inputext = .capnp
@@ -40,4 +38,22 @@ feature (java) {
   //JAVA_CAPN_Files {
    // tests/capnfiles
   //}
+
+  
+	postbuild += mvn -f port/java versions:set -DnewVersion=`<%cat%> $(MADARA_ROOT)/VERSION.txt`
+	postbuild += mvn -f port/java versions:commit
+        postbuild += mvn -f port/java "-Dtest=ai/madara/tests/basic/**" -P development test
+  	postbuild += mvn -f port/java -DskipTests -P development clean package install
 }
+
+//Amit added this. Couldn't find a better way to selectively add postbuild statements. 
+//Fixme: Add the postbuild statements inside feature(java).
+
+feature (lz4){
+   postbuild += mvn -f port/java "-Dtest=ai/madara/tests/lz4/**" -P development test
+}
+
+feature (ssl){
+  postbuild += mvn -f port/java "-Dtest=ai/madara/tests/ssl/**" -P development test
+}
+


### PR DESCRIPTION
Previously all java tests were executed irrespective of feature [ssl or lz4]. I have refactored and modified the tests to run depending on the build options given in base_build script.