### PR TITLE
Exception uninit

### DIFF
--- a/include/madara/exceptions/UninitializedException.h
+++ b/include/madara/exceptions/UninitializedException.h
@@ -1,0 +1,23 @@
+/* -*- C++ -*- */
+#ifndef _MADARA_EXCEPTIONS_UNINITIALIZEDEXCEPTION_H_
+#define _MADARA_EXCEPTIONS_UNINITIALIZEDEXCEPTION_H_
+
+#include <string>
+#include "MadaraException.h"
+
+namespace madara
+{
+namespace exceptions
+{
+/**
+ * An exception for attempting to access an invalid context1
+ **/
+class UninitializedException : public MadaraException
+{
+public:
+  using MadaraException::MadaraException;
+};
+}
+}
+
+#endif /* _MADARA_EXCEPTIONS_UNINITIALIZEDEXCEPTION_H_ */

--- a/include/madara/expression/VariableNode.cpp
+++ b/include/madara/expression/VariableNode.cpp
@@ -275,7 +275,18 @@ madara::knowledge::KnowledgeRecord madara::expression::VariableNode::evaluate(
   }
   else
   {
-    return context_.get(expand_key(), settings);
+    auto ret = context_.get(expand_key(), settings);
+
+    if (settings.exception_on_unitialized && !ret.exists ())
+    {
+      std::stringstream buffer;
+      buffer << "madara::expression::VariableNode::evaluate: ";
+      buffer << "ERROR: settings do not allow reads of unset vars and ";
+      buffer << ref_.get_name() << " is uninitialized";
+      throw exceptions::UninitializedException (buffer.str ());
+    }
+
+    return ret;
   }
 }
 

--- a/include/madara/knowledge/EvalSettings.h
+++ b/include/madara/knowledge/EvalSettings.h
@@ -97,6 +97,9 @@ struct MADARA_EXPORT EvalSettings : public KnowledgeUpdateSettings
    * @param  t_treat_locals_as_globals true if local variable changes should
    *                                   be sent over the network (dangerous).
    *                                   @see treat_locals_as_globals
+   * @param  t_stream_changes          true if changes must be streamed
+   * @param  t_exceptions_on_unitialized true if exceptions must be thrown
+   *                                   when reading uninitialized variables
    **/
   explicit EvalSettings(bool t_delay_sending_modifieds,
       bool t_treat_globals_as_locals = false, bool t_signal_updates = true,
@@ -104,10 +107,14 @@ struct MADARA_EXPORT EvalSettings : public KnowledgeUpdateSettings
       bool t_track_local_changes = false,
       std::string t_pre_print_statement = "",
       std::string t_post_print_statement = "", uint64_t t_clock_increment = 1,
-      bool t_treat_locals_as_globals = false)
+      bool t_treat_locals_as_globals = false,
+      bool t_stream_changes = true,
+      bool t_exceptions_on_unitialized = false)
     : KnowledgeUpdateSettings(t_treat_globals_as_locals, t_signal_updates,
           t_always_overwrite, t_always_expand, t_track_local_changes,
-          t_clock_increment, t_treat_locals_as_globals),
+          t_clock_increment, t_treat_locals_as_globals,
+          t_stream_changes,
+          t_exceptions_on_unitialized),
       delay_sending_modifieds(t_delay_sending_modifieds),
       pre_print_statement(t_pre_print_statement),
       post_print_statement(t_post_print_statement)

--- a/include/madara/knowledge/KnowledgeReferenceSettings.h
+++ b/include/madara/knowledge/KnowledgeReferenceSettings.h
@@ -29,21 +29,30 @@ public:
   /**
    * Constructor
    **/
-  KnowledgeReferenceSettings() : expand_variables(true), never_exit(false) {}
+  KnowledgeReferenceSettings()
+   : expand_variables(true), never_exit(false),
+     exception_on_unitialized(false)
+  {
+  }
 
   /**
    * Constructor
+   * @param t_expand_variables  if true, perform variable expansion
+   * @param t_exception         if uninitialized variable, throw exception
    **/
-  KnowledgeReferenceSettings(bool t_expand_variables)
-    : expand_variables(t_expand_variables), never_exit(false)
+  KnowledgeReferenceSettings(bool t_expand_variables, bool t_exception=false)
+    : expand_variables(t_expand_variables), never_exit(false),
+     exception_on_unitialized(t_exception)
   {
   }
 
   /**
    * Copy constructor
+   * @param rhs                 reference to copy
    **/
   KnowledgeReferenceSettings(const KnowledgeReferenceSettings& rhs)
-    : expand_variables(rhs.expand_variables), never_exit(rhs.never_exit)
+    : expand_variables(rhs.expand_variables), never_exit(rhs.never_exit),
+      exception_on_unitialized(rhs.exception_on_unitialized)
   {
   }
 
@@ -62,6 +71,9 @@ public:
    * Never allow MADARA to exit, even with fatal errors or invalid state
    **/
   bool never_exit;
+
+  /// throw an exception if reference is on uninitialized variable
+  bool exception_on_unitialized;
 };
 }
 }

--- a/include/madara/knowledge/KnowledgeUpdateSettings.h
+++ b/include/madara/knowledge/KnowledgeUpdateSettings.h
@@ -53,13 +53,16 @@ public:
    * @param  t_treat_locals_as_globals true if local variable changes should
    *                                   be sent over the network (dangerous).
    *                                   @see treat_locals_as_globals
+   * @param  t_stream_changes          true if changes must be streamed
+   * @param  t_exceptions_on_unitialized true if exceptions must be thrown
+   *                                   when reading uninitialized variables
    **/
   KnowledgeUpdateSettings(bool t_treat_globals_as_locals,
       bool t_signal_changes = true, bool t_always_overwrite = false,
       bool t_always_expand = true, bool t_track_local_changes = true,
       uint64_t t_clock_increment = 1, bool t_treat_locals_as_globals = false,
-      bool t_stream_changes = true)
-    : KnowledgeReferenceSettings(t_always_expand),
+      bool t_stream_changes = true, bool t_exceptions_on_unitialized = false)
+    : KnowledgeReferenceSettings(t_always_expand, t_exceptions_on_unitialized),
       treat_globals_as_locals(t_treat_globals_as_locals),
       signal_changes(t_signal_changes),
       always_overwrite(t_always_overwrite),

--- a/include/madara/knowledge/WaitSettings.h
+++ b/include/madara/knowledge/WaitSettings.h
@@ -93,17 +93,23 @@ struct WaitSettings : public EvalSettings
    * @param  t_treat_locals_as_globals true if local variable changes should
    *                                   be sent over the network (dangerous).
    *                                   @see treat_locals_as_globals
+   * @param  t_stream_changes          true if changes must be streamed
+   * @param  t_exceptions_on_unitialized true if exceptions must be thrown
+   *                                   when reading uninitialized variables
    **/
   WaitSettings(bool t_delay_sending_modifieds, bool t_treat_globals_as_locals,
       bool t_signal_updates, bool t_always_overwrite, bool t_always_expand,
       bool t_track_local_changes, std::string t_pre_print_statement,
       std::string t_post_print_statement, double t_poll_frequency,
       double t_max_wait_time, uint64_t t_clock_increment = 1,
-      bool t_treat_locals_as_globals = false)
+      bool t_treat_locals_as_globals = false,
+      bool t_stream_changes = true,
+      bool t_exceptions_on_unitialized = false)
     : EvalSettings(t_delay_sending_modifieds, t_treat_globals_as_locals,
           t_signal_updates, t_always_overwrite, t_always_expand,
           t_track_local_changes, t_pre_print_statement, t_post_print_statement,
-          t_clock_increment, t_treat_locals_as_globals),
+          t_clock_increment, t_treat_locals_as_globals, t_stream_changes,
+          t_exceptions_on_unitialized),
       poll_frequency(t_poll_frequency),
       max_wait_time(t_max_wait_time)
   {

--- a/tests/test_karl_exceptions.cpp
+++ b/tests/test_karl_exceptions.cpp
@@ -398,6 +398,7 @@ void test_unitialized(void)
 {
   knowledge::KnowledgeBase kb;
   knowledge::EvalSettings settings;
+  settings.exception_on_unitialized = true;
 
   std::cerr << "##########################\n";
   std::cerr << "TESTING UNINITIALIZED VARS\n";
@@ -418,7 +419,7 @@ void test_unitialized(void)
   
   kb.clear();
 
-  logger::global_logger->set_level (6);
+  // logger::global_logger->set_level (6);
 
   // Attempting to set kb with exception eval settings
   std::cerr << "Testing evaluate with exception settings: ";
@@ -485,6 +486,21 @@ void test_unitialized(void)
   try
   {
     kb.get("var1");
+    std::cerr << "SUCCESS\n";
+  }
+  catch(exceptions::UninitializedException&)
+  {
+    std::cerr << "FAIL\n";
+    ++madara_fails;
+  }
+
+  kb.clear();
+
+  // Attempting to get uninitialized with exception eval settings
+  std::cerr << "Testing get with exception settings: ";
+  try
+  {
+    kb.get("var1", settings);
     std::cerr << "FAIL\n";
     ++madara_fails;
   }
@@ -496,10 +512,25 @@ void test_unitialized(void)
   kb.clear();
 
   // Attempting to get uninitialized with exception eval settings
-  std::cerr << "Testing get with exception settings: ";
+  std::cerr << "Testing retrieve_index with default settings: ";
   try
   {
-    kb.get("var1", settings);
+    kb.retrieve_index("var1", 1);
+    std::cerr << "SUCCESS\n";
+  }
+  catch(exceptions::UninitializedException&)
+  {
+    std::cerr << "FAIL\n";
+    ++madara_fails;
+  }
+
+  kb.clear();
+
+  // Attempting to get uninitialized with exception eval settings
+  std::cerr << "Testing retrieve_index with exception settings: ";
+  try
+  {
+    kb.retrieve_index("var1", 1, settings);
     std::cerr << "FAIL\n";
     ++madara_fails;
   }

--- a/tests/test_karl_exceptions.cpp
+++ b/tests/test_karl_exceptions.cpp
@@ -8,6 +8,7 @@
 namespace knowledge = madara::knowledge;
 namespace expression = madara::expression;
 namespace exceptions = madara::exceptions;
+namespace logger = madara::logger;
 
 int madara_fails(0);
 
@@ -21,11 +22,11 @@ void test_functions(void)
   std::cerr << "Testing undefined function: ";
   try
   {
-    knowledge.evaluate("not_defined ()");
+    knowledge.evaluate("not_defined()");
     std::cerr << "FAIL\n";
     ++madara_fails;
   }
-  catch (exceptions::KarlException&)
+  catch(exceptions::KarlException&)
   {
     std::cerr << "SUCCESS\n";
   }
@@ -33,11 +34,11 @@ void test_functions(void)
   std::cerr << "Testing undefined system function: ";
   try
   {
-    knowledge.evaluate("#not_defined ()");
+    knowledge.evaluate("#not_defined()");
     std::cerr << "FAIL\n";
     ++madara_fails;
   }
-  catch (exceptions::KarlException&)
+  catch(exceptions::KarlException&)
   {
     std::cerr << "SUCCESS\n";
   }
@@ -57,7 +58,7 @@ void test_bad_operators(void)
     std::cerr << "FAIL\n";
     ++madara_fails;
   }
-  catch (exceptions::KarlException&)
+  catch(exceptions::KarlException&)
   {
     std::cerr << "SUCCESS\n";
   }
@@ -69,7 +70,7 @@ void test_bad_operators(void)
     std::cerr << "FAIL\n";
     ++madara_fails;
   }
-  catch (exceptions::KarlException&)
+  catch(exceptions::KarlException&)
   {
     std::cerr << "SUCCESS\n";
   }
@@ -81,7 +82,7 @@ void test_bad_operators(void)
     std::cerr << "FAIL\n";
     ++madara_fails;
   }
-  catch (exceptions::KarlException&)
+  catch(exceptions::KarlException&)
   {
     std::cerr << "SUCCESS\n";
   }
@@ -93,7 +94,7 @@ void test_bad_operators(void)
     std::cerr << "FAIL\n";
     ++madara_fails;
   }
-  catch (exceptions::KarlException&)
+  catch(exceptions::KarlException&)
   {
     std::cerr << "SUCCESS\n";
   }
@@ -105,7 +106,7 @@ void test_bad_operators(void)
     std::cerr << "FAIL\n";
     ++madara_fails;
   }
-  catch (exceptions::KarlException&)
+  catch(exceptions::KarlException&)
   {
     std::cerr << "SUCCESS\n";
   }
@@ -117,7 +118,7 @@ void test_bad_operators(void)
     std::cerr << "FAIL\n";
     ++madara_fails;
   }
-  catch (exceptions::KarlException&)
+  catch(exceptions::KarlException&)
   {
     std::cerr << "SUCCESS\n";
   }
@@ -129,7 +130,7 @@ void test_bad_operators(void)
     std::cerr << "FAIL\n";
     ++madara_fails;
   }
-  catch (exceptions::KarlException&)
+  catch(exceptions::KarlException&)
   {
     std::cerr << "SUCCESS\n";
   }
@@ -141,7 +142,7 @@ void test_bad_operators(void)
     std::cerr << "FAIL\n";
     ++madara_fails;
   }
-  catch (exceptions::KarlException&)
+  catch(exceptions::KarlException&)
   {
     std::cerr << "SUCCESS\n";
   }
@@ -153,7 +154,7 @@ void test_bad_operators(void)
     std::cerr << "FAIL\n";
     ++madara_fails;
   }
-  catch (exceptions::KarlException&)
+  catch(exceptions::KarlException&)
   {
     std::cerr << "SUCCESS\n";
   }
@@ -165,7 +166,7 @@ void test_bad_operators(void)
     std::cerr << "FAIL\n";
     ++madara_fails;
   }
-  catch (exceptions::KarlException&)
+  catch(exceptions::KarlException&)
   {
     std::cerr << "SUCCESS\n";
   }
@@ -187,8 +188,8 @@ void test_nan(void)
   std::cerr << "Evaluating var3 = 1/var0...\n";
   knowledge.evaluate("var3 = 1/var0");
 
-  std::cerr << "Evaluating var4 = #sqrt (-1)...\n";
-  knowledge.evaluate("var4 = #sqrt (-1)");
+  std::cerr << "Evaluating var4 = #sqrt(-1)...\n";
+  knowledge.evaluate("var4 = #sqrt(-1)");
 
   std::cerr << "Evaluating var5 = nan...\n";
   knowledge.evaluate("var5 = nan");
@@ -197,7 +198,7 @@ void test_nan(void)
   knowledge.evaluate("var6 = var5 != var5");
 
   std::cerr << "Testing divide by zero: ";
-  if (knowledge.get("var1") != knowledge.get("var1"))
+  if(knowledge.get("var1") != knowledge.get("var1"))
   {
     std::cerr << "SUCCESS\n";
   }
@@ -208,7 +209,7 @@ void test_nan(void)
   }
 
   std::cerr << "Testing variable divide by zero: ";
-  if (knowledge.get("var2") != knowledge.get("var2"))
+  if(knowledge.get("var2") != knowledge.get("var2"))
   {
     std::cerr << "SUCCESS\n";
   }
@@ -219,7 +220,7 @@ void test_nan(void)
   }
 
   std::cerr << "Testing divide by variable zero: ";
-  if (knowledge.get("var3") != knowledge.get("var3"))
+  if(knowledge.get("var3") != knowledge.get("var3"))
   {
     std::cerr << "SUCCESS\n";
   }
@@ -230,7 +231,7 @@ void test_nan(void)
   }
 
   std::cerr << "Testing sqrt(-1): ";
-  if (knowledge.get("var4") != knowledge.get("var4"))
+  if(knowledge.get("var4") != knowledge.get("var4"))
   {
     std::cerr << "SUCCESS\n";
   }
@@ -241,7 +242,7 @@ void test_nan(void)
   }
 
   std::cerr << "Testing assignment of nan: ";
-  if (knowledge.get("var5") != knowledge.get("var5"))
+  if(knowledge.get("var5") != knowledge.get("var5"))
   {
     std::cerr << "SUCCESS\n";
   }
@@ -252,8 +253,8 @@ void test_nan(void)
     std::cerr << "var5 = " << knowledge.get("var5") << "\n";
   }
 
-  std::cerr << "Testing nan check (var != var): ";
-  if (knowledge.get("var6").is_true())
+  std::cerr << "Testing nan check(var != var): ";
+  if(knowledge.get("var6").is_true())
   {
     std::cerr << "SUCCESS\n";
   }
@@ -271,7 +272,7 @@ void test_nan(void)
     std::cerr << "FAIL\n";
     ++madara_fails;
   }
-  catch (exceptions::KarlException&)
+  catch(exceptions::KarlException&)
   {
     std::cerr << "SUCCESS\n";
   }
@@ -287,60 +288,60 @@ void test_empty_assignment(void)
 
   try
   {
-    std::cerr << "Testing assignment (-=): ";
+    std::cerr << "Testing assignment(-=): ";
     knowledge.evaluate("-= 5");
     std::cerr << "FAIL\n";
     ++madara_fails;
   }
-  catch (exceptions::KarlException&)
+  catch(exceptions::KarlException&)
   {
     std::cerr << "SUCCESS\n";
   }
 
   try
   {
-    std::cerr << "Testing assignment (+=): ";
+    std::cerr << "Testing assignment(+=): ";
     knowledge.evaluate("+= 5");
     std::cerr << "FAIL\n";
     ++madara_fails;
   }
-  catch (exceptions::KarlException&)
+  catch(exceptions::KarlException&)
   {
     std::cerr << "SUCCESS\n";
   }
 
   try
   {
-    std::cerr << "Testing assignment (*=): ";
+    std::cerr << "Testing assignment(*=): ";
     knowledge.evaluate("*= 5");
     std::cerr << "FAIL\n";
     ++madara_fails;
   }
-  catch (exceptions::KarlException&)
+  catch(exceptions::KarlException&)
   {
     std::cerr << "SUCCESS\n";
   }
 
   try
   {
-    std::cerr << "Testing assignment (/=): ";
+    std::cerr << "Testing assignment(/=): ";
     knowledge.evaluate("/= 5");
     std::cerr << "FAIL\n";
     ++madara_fails;
   }
-  catch (exceptions::KarlException&)
+  catch(exceptions::KarlException&)
   {
     std::cerr << "SUCCESS\n";
   }
 
   try
   {
-    std::cerr << "Testing assignment (=): ";
+    std::cerr << "Testing assignment(=): ";
     knowledge.evaluate("= 5");
     std::cerr << "FAIL\n";
     ++madara_fails;
   }
-  catch (exceptions::KarlException&)
+  catch(exceptions::KarlException&)
   {
     std::cerr << "SUCCESS\n";
   }
@@ -370,7 +371,7 @@ void test_min(void)
 
   std::cerr << "Testing " << karl_min << " evaluation: ";
 
-  if (local_min == global_min)
+  if(local_min == global_min)
     std::cerr << "SUCCESS\n";
   else
   {
@@ -382,7 +383,7 @@ void test_min(void)
 
   std::cerr << "Testing " << karl_max << " evaluation: ";
 
-  if (local_max == global_max)
+  if(local_max == global_max)
     std::cerr << "SUCCESS\n";
   else
   {
@@ -393,6 +394,122 @@ void test_min(void)
   }
 }
 
+void test_unitialized(void)
+{
+  knowledge::KnowledgeBase kb;
+  knowledge::EvalSettings settings;
+
+  std::cerr << "##########################\n";
+  std::cerr << "TESTING UNINITIALIZED VARS\n";
+  std::cerr << "##########################\n";
+
+  // Attempting to set kb with normal eval settings
+  std::cerr << "Testing evaluate with default settings: ";
+  try
+  {
+    kb.evaluate("var1 = var2");
+    std::cerr << "SUCCESS\n";
+  }
+  catch(exceptions::UninitializedException&)
+  {
+    std::cerr << "FAIL\n";
+    ++madara_fails;
+  }
+  
+  kb.clear();
+
+  logger::global_logger->set_level (6);
+
+  // Attempting to set kb with exception eval settings
+  std::cerr << "Testing evaluate with exception settings: ";
+  try
+  {
+    kb.evaluate("var1 = var2", settings);
+    std::cerr << "FAIL\n";
+    ++madara_fails;
+  }
+  catch(exceptions::UninitializedException&)
+  {
+    std::cerr << "SUCCESS\n";
+  }
+
+  kb.clear();
+
+  // Attempting to set kb with exception eval settings
+  std::cerr << "Testing multi-part evaluate with exception settings: ";
+  try
+  {
+    kb.evaluate("var1 = 0; var2 = 0; var3 = var4; var4 = 4", settings);
+    std::cerr << "FAIL\n";
+    ++madara_fails;
+  }
+  catch(exceptions::UninitializedException&)
+  {
+    std::cerr << "SUCCESS\n";
+  }
+
+  kb.clear();
+
+  // Attempting to set kb with exception eval settings
+  std::cerr << "Testing array ref evaluate with exception settings: ";
+  try
+  {
+    kb.evaluate("var1 = var2[3]", settings);
+    std::cerr << "FAIL\n";
+    ++madara_fails;
+  }
+  catch(exceptions::UninitializedException&)
+  {
+    std::cerr << "SUCCESS\n";
+  }
+
+  kb.clear();
+
+  // Attempting to set kb with exception eval settings
+  std::cerr << "Testing multi-part evaluate with exception settings: ";
+  try
+  {
+    kb.evaluate("var1 = 3; var2 = var1; var3 = 4; var4 = var3", settings);
+    std::cerr << "SUCCESS\n";
+  }
+  catch(exceptions::UninitializedException&)
+  {
+    std::cerr << "FAIL\n";
+    ++madara_fails;
+  }
+
+  kb.clear();
+
+  // Attempting to get uninitialized with exception eval settings
+  std::cerr << "Testing get with default settings: ";
+  try
+  {
+    kb.get("var1");
+    std::cerr << "FAIL\n";
+    ++madara_fails;
+  }
+  catch(exceptions::UninitializedException&)
+  {
+    std::cerr << "SUCCESS\n";
+  }
+
+  kb.clear();
+
+  // Attempting to get uninitialized with exception eval settings
+  std::cerr << "Testing get with exception settings: ";
+  try
+  {
+    kb.get("var1", settings);
+    std::cerr << "FAIL\n";
+    ++madara_fails;
+  }
+  catch(exceptions::UninitializedException&)
+  {
+    std::cerr << "SUCCESS\n";
+  }
+
+}
+
 int main(int, char**)
 {
   test_functions();
@@ -400,8 +517,9 @@ int main(int, char**)
   test_min();
   test_empty_assignment();
   test_bad_operators();
+  test_unitialized();
 
-  if (madara_fails > 0)
+  if(madara_fails > 0)
   {
     std::cerr << "OVERALL: FAIL. " << madara_fails << " tests failed.\n";
   }

--- a/tools/stk_inspect.cpp
+++ b/tools/stk_inspect.cpp
@@ -252,7 +252,7 @@ int64_t process_command (const std::string & command,
     }
     else if(utility::begins_with(logic, "help"))
     {
-      // format: print
+      // format: help
       std::cout << "\n";
       std::cout << last_toi << ": Executing help... commands available:\n\n";
       
@@ -267,7 +267,7 @@ int64_t process_command (const std::string & command,
       std::cout << "     print_stats: print current var stats\n";
       std::cout << "       print_all: print current knowledge & var stats\n";
       std::cout << "            quit: leave interactive shell\n";
-      std::cout << "           shell: enter and interactive shell\n\n";
+      std::cout << "           shell: enter interactive shell\n\n";
 
       ++result;
     }
@@ -814,8 +814,6 @@ void handle_arguments(int argc, char** argv)
           "  [-kp|--print-prefix pfx] filter prints by prefix. Can be "
           "multiple.\n"
           "  [-ks|--print-stats]      print stats knowledge base contents\n"
-          "  [-ky]                    print knowledge after frequent "
-          "evaluations\n"
           "  [-l|--level level]       the logger level(0+, higher is higher "
           "detail)\n"
           "  [-lcp|--load-checkpoint-prefix prfx]\n"


### PR DESCRIPTION
Implements a feature request for a setting to allow for throwing an exception when trying to retrieve an uninitialized variable. This can be used on evaluate/wait or get/retrieve_index.