### PR TITLE
* Updating KnowledgeBaseImpl to include a mutex specifically for chan…

### DIFF
--- a/include/madara/knowledge/KnowledgeBaseImpl.h
+++ b/include/madara/knowledge/KnowledgeBaseImpl.h
@@ -1131,6 +1131,8 @@ private:
   ThreadSafeContext map_;
   std::string id_;
   transport::QoSTransportSettings settings_;
+  
+  mutable MADARA_LOCK_TYPE transport_mutex_;
 
   std::vector<std::unique_ptr<transport::Base>> transports_;
 };

--- a/include/madara/knowledge/KnowledgeBaseImpl.inl
+++ b/include/madara/knowledge/KnowledgeBaseImpl.inl
@@ -210,7 +210,7 @@ inline int KnowledgeBaseImpl::read_file(const VariableReference& variable,
 
 inline void KnowledgeBaseImpl::activate_transport(void)
 {
-  MADARA_GUARD_TYPE guard(map_.mutex_);
+  MADARA_GUARD_TYPE guard(transport_mutex_);
 
   if (transports_.size() == 0)
   {
@@ -392,7 +392,7 @@ inline KnowledgeRecord KnowledgeBaseImpl::evaluate(
 
 inline size_t KnowledgeBaseImpl::attach_transport(transport::Base* transport)
 {
-  MADARA_GUARD_TYPE guard(map_.mutex_);
+  MADARA_GUARD_TYPE guard(transport_mutex_);
 
   transports_.emplace_back(transport);
   return transports_.size();
@@ -400,7 +400,7 @@ inline size_t KnowledgeBaseImpl::attach_transport(transport::Base* transport)
 
 inline size_t KnowledgeBaseImpl::get_num_transports(void)
 {
-  MADARA_GUARD_TYPE guard(map_.mutex_);
+  MADARA_GUARD_TYPE guard(transport_mutex_);
 
   return transports_.size();
 }
@@ -410,7 +410,8 @@ inline size_t KnowledgeBaseImpl::remove_transport(size_t index)
   std::unique_ptr<transport::Base> transport;
   size_t size = 0;
   {
-    MADARA_GUARD_TYPE guard(map_.mutex_);
+    MADARA_GUARD_TYPE guard(transport_mutex_);
+
     size = transports_.size();
     if (index < size)
     {

--- a/include/madara/knowledge/ThreadSafeContext.h
+++ b/include/madara/knowledge/ThreadSafeContext.h
@@ -884,6 +884,12 @@ public:
   const VariableReferenceMap& get_modifieds(void) const;
 
   /**
+   * Retrieves the current modifieds map
+   * @return  the modified knowledge records
+   **/
+  KnowledgeMap get_modifieds_current(void) const;
+
+  /**
    * Adds a list of VariableReferences to the current modified list.
    * @param  modifieds  a list of variables to add to modified list
    **/

--- a/include/madara/knowledge/ThreadSafeContext.inl
+++ b/include/madara/knowledge/ThreadSafeContext.inl
@@ -1014,6 +1014,20 @@ inline const VariableReferenceMap& ThreadSafeContext::get_modifieds(void) const
   return changed_map_;
 }
 
+inline KnowledgeMap ThreadSafeContext::get_modifieds_current(void) const
+{
+  MADARA_GUARD_TYPE guard(mutex_);
+
+  KnowledgeMap map;
+
+  for (auto entry: changed_map_)
+  {
+    map[entry.first] = *entry.second.get_record_unsafe ();
+  }
+
+  return map;
+}
+
 inline VariableReferences ThreadSafeContext::save_modifieds(void) const
 {
   MADARA_GUARD_TYPE guard(mutex_);

--- a/include/madara/transport/Transport.cpp
+++ b/include/madara/transport/Transport.cpp
@@ -809,7 +809,7 @@ int prep_rebroadcast(knowledge::ThreadSafeContext& context, char* buffer,
   return result;
 }
 
-long Base::prep_send(const knowledge::VariableReferenceMap& orig_updates,
+long Base::prep_send(const knowledge::KnowledgeMap& orig_updates,
     const char* print_prefix)
 {
   // check to see if we are shutting down
@@ -883,16 +883,16 @@ long Base::prep_send(const knowledge::VariableReferenceMap& orig_updates,
             " Calling filter chain of %s.\n",
             print_prefix, e.first);
 
-        const auto* record = e.second.get_record_unsafe();
+        const auto record = e.second;
 
-        if (record->toi() > latest_toi)
+        if (record.toi() > latest_toi)
         {
-          latest_toi = record->toi();
+          latest_toi = record.toi();
         }
 
         // filter the record according to the send filter chain
         knowledge::KnowledgeRecord result =
-            settings_.filter_send(*record, e.first, transport_context);
+            settings_.filter_send(record, e.first, transport_context);
 
         madara_logger_log(context_.get_logger(), logger::LOG_MAJOR,
             "%s:"
@@ -940,11 +940,11 @@ long Base::prep_send(const knowledge::VariableReferenceMap& orig_updates,
     {
       for (auto e : orig_updates)
       {
-        const auto* record = e.second.get_record_unsafe();
+        const auto record = e.second;
 
-        if (record->toi() > latest_toi)
+        if (record.toi() > latest_toi)
         {
-          latest_toi = record->toi();
+          latest_toi = record.toi();
         }
 
         if (record)
@@ -954,7 +954,7 @@ long Base::prep_send(const knowledge::VariableReferenceMap& orig_updates,
               " Adding record %s to update list.\n",
               print_prefix, e.first);
 
-          filtered_updates.emplace(std::make_pair(e.first, *record));
+          filtered_updates.emplace(std::make_pair(e.first, record));
         }
         else
         {

--- a/include/madara/transport/Transport.h
+++ b/include/madara/transport/Transport.h
@@ -96,7 +96,7 @@ public:
    *                0   No message to send
    *               > 0  size of buffered message
    **/
-  long prep_send(const knowledge::VariableReferenceMap& orig_updates,
+  long prep_send(const knowledge::KnowledgeMap& orig_updates,
       const char* print_prefix);
 
   /**
@@ -109,7 +109,7 @@ public:
    *
    * @return  result of operation or -1 if we are shutting down
    **/
-  virtual long send_data(const knowledge::VariableReferenceMap&) = 0;
+  virtual long send_data(const knowledge::KnowledgeMap&) = 0;
 
   /**
    * Invalidates a transport to indicate it is shutting down

--- a/include/madara/transport/ndds/NddsTransport.cpp
+++ b/include/madara/transport/ndds/NddsTransport.cpp
@@ -272,7 +272,7 @@ int madara::transport::NddsTransport::setup(void)
 }
 
 long madara::transport::NddsTransport::send_data(
-    const knowledge::VariableReferenceMap& updates)
+    const knowledge::KnowledgeMap& updates)
 {
   long result = prep_send(updates, "NddsTransport::send_data:");
 

--- a/include/madara/transport/ndds/NddsTransport.h
+++ b/include/madara/transport/ndds/NddsTransport.h
@@ -42,7 +42,7 @@ public:
    * @param   updates listing of all updates that must be sent
    * @return  result of write operation or -1 if we are shutting down
    **/
-  long send_data(const knowledge::VariableReferenceMap& updates) override;
+  long send_data(const knowledge::KnowledgeMap& updates) override;
 
   /**
    * Accesses reliability setting

--- a/include/madara/transport/splice/SpliceDDSTransport.cpp
+++ b/include/madara/transport/splice/SpliceDDSTransport.cpp
@@ -396,7 +396,7 @@ int madara::transport::SpliceDDSTransport::setup(void)
 }
 
 long madara::transport::SpliceDDSTransport::send_data(
-    const knowledge::VariableReferenceMap& updates)
+    const knowledge::KnowledgeMap& updates)
 {
   long result = 0;
 

--- a/include/madara/transport/splice/SpliceDDSTransport.h
+++ b/include/madara/transport/splice/SpliceDDSTransport.h
@@ -52,7 +52,7 @@ public:
    * @param   updates listing of all updates that must be sent
    * @return  result of write operation or -1 if we are shutting down
    **/
-  long send_data(const knowledge::VariableReferenceMap& updates) override;
+  long send_data(const knowledge::KnowledgeMap& updates) override;
 
   /**
    * Accesses reliability setting

--- a/include/madara/transport/udp/UdpRegistryClient.cpp
+++ b/include/madara/transport/udp/UdpRegistryClient.cpp
@@ -115,7 +115,7 @@ void UdpRegistryClient::send_register(void)
 }
 
 long UdpRegistryClient::send_data(
-    const knowledge::VariableReferenceMap& orig_updates)
+    const knowledge::KnowledgeMap& orig_updates)
 {
   if (!settings_.no_sending)
   {

--- a/include/madara/transport/udp/UdpRegistryClient.h
+++ b/include/madara/transport/udp/UdpRegistryClient.h
@@ -60,7 +60,7 @@ public:
    * @return  result of write operation or -1 if we are shutting down
    **/
   long send_data(
-      const madara::knowledge::VariableReferenceMap& updates) override;
+      const madara::knowledge::KnowledgeMap& updates) override;
 
   int setup(void) override;
 

--- a/include/madara/transport/udp/UdpRegistryServer.cpp
+++ b/include/madara/transport/udp/UdpRegistryServer.cpp
@@ -30,7 +30,7 @@ int madara::transport::UdpRegistryServer::setup(void)
 }
 
 long madara::transport::UdpRegistryServer::send_data(
-    const madara::knowledge::VariableReferenceMap& orig_updates)
+    const madara::knowledge::KnowledgeMap& orig_updates)
 {
   if (!settings_.no_sending)
   {

--- a/include/madara/transport/udp/UdpRegistryServer.h
+++ b/include/madara/transport/udp/UdpRegistryServer.h
@@ -48,7 +48,7 @@ public:
    * @return  result of write operation or -1 if we are shutting down
    **/
   long send_data(
-      const madara::knowledge::VariableReferenceMap& updates) override;
+      const madara::knowledge::KnowledgeMap& updates) override;
 
   int setup(void) override;
 

--- a/include/madara/transport/udp/UdpTransport.cpp
+++ b/include/madara/transport/udp/UdpTransport.cpp
@@ -256,7 +256,7 @@ long UdpTransport::send_message(const char* buf, size_t packet_size)
 }
 
 long UdpTransport::send_data(
-    const knowledge::VariableReferenceMap& orig_updates)
+    const knowledge::KnowledgeMap& orig_updates)
 {
   long result(0);
   const char* print_prefix = "UdpTransport::send_data";

--- a/include/madara/transport/udp/UdpTransport.h
+++ b/include/madara/transport/udp/UdpTransport.h
@@ -60,7 +60,7 @@ public:
    * @return  result of write operation or -1 if we are shutting down
    **/
   long send_data(
-      const madara::knowledge::VariableReferenceMap& updates) override;
+      const madara::knowledge::KnowledgeMap& updates) override;
 
   /// sent packets
   knowledge::containers::Integer sent_packets;

--- a/include/madara/transport/zmq/ZMQTransport.cpp
+++ b/include/madara/transport/zmq/ZMQTransport.cpp
@@ -251,7 +251,7 @@ int madara::transport::ZMQTransport::setup(void)
 }
 
 long madara::transport::ZMQTransport::send_data(
-    const madara::knowledge::VariableReferenceMap& orig_updates)
+    const madara::knowledge::KnowledgeMap& orig_updates)
 {
   long result(0);
   const char* print_prefix = "ZMQTransport::send_data";

--- a/include/madara/transport/zmq/ZMQTransport.h
+++ b/include/madara/transport/zmq/ZMQTransport.h
@@ -65,7 +65,7 @@ public:
    * @return  result of write operation or -1 if we are shutting down
    **/
   long send_data(
-      const madara::knowledge::VariableReferenceMap& updates) override;
+      const madara::knowledge::KnowledgeMap& updates) override;
 
   /**
    * Closes the transport


### PR DESCRIPTION
…ging, using or retrieving transports

  * Stops us from having to lock KB during entire send_modifieds
  * Should open up massive multi-threading gains
* Added get_modifieds_current to ThreadSafeContext
  * Using this instead of get_modifieds to provide KnowledgeMap in send_modifieds
  * Allows all transports to have a consistent KnowledgeMap, regardless of order, and without needing a context mutex protection