### PR TITLE
* Added capability to apply buffer filters to large UDP packets (>64K…

### DIFF
--- a/Tests.mpc
+++ b/Tests.mpc
@@ -171,7 +171,7 @@ project (Test_Counter) : using_madara, no_karl, no_xml, null_lock, using_simtime
   }
 }
 
-project (Test_Fragmentation) : using_madara, no_karl, no_xml, null_lock, using_simtime {
+project (Test_Fragmentation) : using_madara, no_karl, no_xml, null_lock, using_simtime, using_ssl {
   exeout = $(MADARA_ROOT)/bin
   exename = test_fragmentation
   
@@ -539,7 +539,7 @@ project (Network_Counter_Filter) : using_madara, no_karl, no_xml, null_lock, usi
   }
 }
 
-project (Network_Profiler) : using_madara, no_karl, no_xml, null_lock, using_simtime {
+project (Network_Profiler) : using_madara, no_karl, no_xml, null_lock, using_simtime, using_ssl, using_lz4 {
   exeout = $(MADARA_ROOT)/bin
   exename = network_profiler
   

--- a/include/madara/filters/BufferFilterHeader.h
+++ b/include/madara/filters/BufferFilterHeader.h
@@ -83,17 +83,17 @@ public:
   /**
    * the size of this header plus the updates
    **/
-  uint64_t size;
+  uint64_t size = 0;
 
   /**
    * filter id
    **/
-  char id[8];
+  char id[8] = {'\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0'};
 
   /**
    * filter version
    **/
-  uint32_t version;
+  uint32_t version = 0;
 };
 }
 }

--- a/include/madara/knowledge/CheckpointSettings.h
+++ b/include/madara/knowledge/CheckpointSettings.h
@@ -302,7 +302,7 @@ public:
         {
           madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_ERROR,
               "CheckpointSettings::decode: buffer filter %s doesn't match."
-              " Returning 0.",
+              " Returning 0.\n",
               header.id);
 
           return 0;

--- a/include/madara/transport/Fragmentation.cpp
+++ b/include/madara/transport/Fragmentation.cpp
@@ -1,13 +1,15 @@
 #include "Fragmentation.h"
 #include "ReducedMessageHeader.h"
+#include "madara/exceptions/MemoryException.h"
 #include "madara/utility/Utility.h"
 #include "madara/logger/GlobalLogger.h"
 
 #include <algorithm>
 #include <time.h>
+#include <sstream>
 
 madara::transport::FragmentMessageHeader::FragmentMessageHeader()
-  : MessageHeader(), update_number(0)
+  : MessageHeader(), update_number(0), total_size(0)
 {
   memcpy(madara_id, FRAGMENTATION_MADARA_ID, 7);
   madara_id[7] = 0;
@@ -20,124 +22,262 @@ madara::transport::FragmentMessageHeader::~FragmentMessageHeader() {}
 
 uint32_t madara::transport::FragmentMessageHeader::encoded_size(void) const
 {
-  return sizeof(uint64_t) * 3  // size, clock, timestamp
-         + sizeof(char) * (MADARA_IDENTIFIER_LENGTH + MADARA_DOMAIN_MAX_LENGTH +
-                              MAX_ORIGINATOR_LENGTH + 1) +
-         sizeof(uint32_t) * 4;  // type, updates, quality, update_number
+  return sizeof(uint64_t) * 4  // size, clock, timestamp, total_size (4)=32
+         + sizeof(char) *(MADARA_IDENTIFIER_LENGTH + MADARA_DOMAIN_MAX_LENGTH +
+                              MAX_ORIGINATOR_LENGTH + 1) + // 8+32+64+1=105
+         sizeof(uint32_t) * 4;  // type, updates, quality, update_number(4)=16
 }
 
 uint32_t madara::transport::FragmentMessageHeader::static_encoded_size(void)
 {
-  return sizeof(uint64_t) * 3  // size, clock, timestamp
-         + sizeof(char) * (MADARA_IDENTIFIER_LENGTH + MADARA_DOMAIN_MAX_LENGTH +
-                              MAX_ORIGINATOR_LENGTH + 1) +
-         sizeof(uint32_t) * 4;  // type, updates, quality, update_number
+  return sizeof(uint64_t) * 4  // size, clock, timestamp, total_size=32
+         + sizeof(char) *(MADARA_IDENTIFIER_LENGTH + MADARA_DOMAIN_MAX_LENGTH +
+                              MAX_ORIGINATOR_LENGTH + 1) + // 8+32+64+1=105
+         sizeof(uint32_t) * 4;  // type, updates, quality, update_number=16
 }
 
 uint32_t madara::transport::FragmentMessageHeader::get_updates(
     const char* buffer)
 {
   buffer += 116;
-  return (madara::utility::endian_swap(*(uint32_t*)buffer));
+  return(madara::utility::endian_swap(*(uint32_t*)buffer));
+}
+
+std::string madara::transport::FragmentMessageHeader::to_string(void)
+{
+  std::stringstream buffer;
+  buffer << "frag 12: ";
+  buffer << "index(4:" << update_number << "), ";
+  buffer << "total_size(8:" << total_size << "), msg: ";
+  buffer << MessageHeader::to_string();
+
+  return buffer.str();
 }
 
 const char* madara::transport::FragmentMessageHeader::read(
     const char* buffer, int64_t& buffer_remaining)
 {
   // Remove size field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(size))
+  if((size_t)buffer_remaining >= sizeof(size))
   {
     memcpy(&size, buffer, sizeof(size));
     size = madara::utility::endian_swap(size);
     buffer += sizeof(size);
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::read: ";
+    buffer << sizeof(size) << " byte size field cannot fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= sizeof(size);
 
   // Remove madara_id field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(char) * MADARA_IDENTIFIER_LENGTH)
+  if((size_t)buffer_remaining >= sizeof(char) * MADARA_IDENTIFIER_LENGTH)
   {
     strncpy(madara_id, buffer, MADARA_IDENTIFIER_LENGTH);
     buffer += sizeof(char) * MADARA_IDENTIFIER_LENGTH;
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::read: ";
+    buffer << MADARA_IDENTIFIER_LENGTH << " byte id encoding cannot fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= sizeof(char) * MADARA_IDENTIFIER_LENGTH;
 
   // Remove domain field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(char) * MADARA_DOMAIN_MAX_LENGTH)
+  if((size_t)buffer_remaining >= sizeof(char) * MADARA_DOMAIN_MAX_LENGTH)
   {
     strncpy(domain, buffer, MADARA_DOMAIN_MAX_LENGTH);
     buffer += sizeof(char) * MADARA_DOMAIN_MAX_LENGTH;
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::read: ";
+    buffer << MADARA_DOMAIN_MAX_LENGTH << " byte domain encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= sizeof(char) * MADARA_DOMAIN_MAX_LENGTH;
 
   // Remove originator from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(char) * MAX_ORIGINATOR_LENGTH)
+  if((size_t)buffer_remaining >= sizeof(char) * MAX_ORIGINATOR_LENGTH)
   {
     strncpy(originator, buffer, MAX_ORIGINATOR_LENGTH);
     buffer += sizeof(char) * MAX_ORIGINATOR_LENGTH;
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::read: ";
+    buffer << MAX_ORIGINATOR_LENGTH << " byte originator encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= sizeof(char) * MAX_ORIGINATOR_LENGTH;
 
   // Remove type field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(type))
+  if((size_t)buffer_remaining >= sizeof(type))
   {
     memcpy(&type, buffer, sizeof(type));
     type = madara::utility::endian_swap(type);
     buffer += sizeof(type);
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::read: ";
+    buffer << sizeof(type) << " byte type encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= sizeof(type);
 
   // Remove updates field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(updates))
+  if((size_t)buffer_remaining >= sizeof(updates))
   {
     memcpy(&updates, buffer, sizeof(updates));
     updates = madara::utility::endian_swap(updates);
     buffer += sizeof(updates);
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::read: ";
+    buffer << sizeof(updates) << " byte updates encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= sizeof(updates);
 
   // Remove quality field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(quality))
+  if((size_t)buffer_remaining >= sizeof(quality))
   {
     memcpy(&quality, buffer, sizeof(quality));
     quality = madara::utility::endian_swap(quality);
     buffer += sizeof(quality);
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::read: ";
+    buffer << sizeof(quality) << " byte quality encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= sizeof(quality);
 
   // Remove clock field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(clock))
+  if((size_t)buffer_remaining >= sizeof(clock))
   {
     memcpy(&clock, buffer, sizeof(clock));
     clock = madara::utility::endian_swap(clock);
     buffer += sizeof(clock);
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::read: ";
+    buffer << sizeof(clock) << " byte clock encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= sizeof(clock);
 
   // Remove timestamp field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(timestamp))
+  if((size_t)buffer_remaining >= sizeof(timestamp))
   {
     memcpy(&timestamp, buffer, sizeof(timestamp));
     timestamp = madara::utility::endian_swap(timestamp);
     buffer += sizeof(timestamp);
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::read: ";
+    buffer << sizeof(timestamp) << " byte timestamp encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= sizeof(timestamp);
 
   // Remove the time to live field from the buffer
-  if (buffer_remaining >= 1)
+  if(buffer_remaining >= 1)
   {
     memcpy(&ttl, buffer, 1);
     buffer += 1;
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::read: ";
+    buffer << "1 byte ttl encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= 1;
 
   // Remove updates field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(update_number))
+  if((size_t)buffer_remaining >= sizeof(update_number))
   {
     memcpy(&update_number, buffer, sizeof(update_number));
     update_number = madara::utility::endian_swap(update_number);
     buffer += sizeof(update_number);
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::read: ";
+    buffer << sizeof(update_number) << " byte update number encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= sizeof(update_number);
+
+  // Remove total size field from the buffer and update accordingly
+  if((size_t)buffer_remaining >= sizeof(total_size))
+  {
+    memcpy(&total_size, buffer, sizeof(total_size));
+    total_size = madara::utility::endian_swap(total_size);
+    buffer += sizeof(total_size);
+  }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::read: ";
+    buffer << sizeof(total_size) << " byte total size encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
+  buffer_remaining -= sizeof(total_size);
 
   return buffer;
 }
@@ -146,91 +286,219 @@ char* madara::transport::FragmentMessageHeader::write(
     char* buffer, int64_t& buffer_remaining)
 {
   // Write size field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(size))
+  if((size_t)buffer_remaining >= sizeof(size))
   {
     *(uint64_t*)buffer = madara::utility::endian_swap(size);
     buffer += sizeof(size);
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::write: ";
+    buffer << sizeof(size) << " byte size encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= sizeof(size);
 
   // Write madara_id field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(char) * MADARA_IDENTIFIER_LENGTH)
+  if((size_t)buffer_remaining >= sizeof(char) * MADARA_IDENTIFIER_LENGTH)
   {
     strncpy(buffer, madara_id, MADARA_IDENTIFIER_LENGTH);
     buffer += sizeof(char) * MADARA_IDENTIFIER_LENGTH;
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::write: ";
+    buffer << MADARA_IDENTIFIER_LENGTH << " byte id encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= sizeof(char) * MADARA_IDENTIFIER_LENGTH;
 
   // Write domain field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(char) * MADARA_DOMAIN_MAX_LENGTH)
+  if((size_t)buffer_remaining >= sizeof(char) * MADARA_DOMAIN_MAX_LENGTH)
   {
     strncpy(buffer, domain, MADARA_DOMAIN_MAX_LENGTH);
     buffer += sizeof(char) * MADARA_DOMAIN_MAX_LENGTH;
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::write: ";
+    buffer << MADARA_DOMAIN_MAX_LENGTH << " byte domain encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= sizeof(char) * MADARA_DOMAIN_MAX_LENGTH;
 
   // Write originator from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(char) * MAX_ORIGINATOR_LENGTH)
+  if((size_t)buffer_remaining >= sizeof(char) * MAX_ORIGINATOR_LENGTH)
   {
     strncpy(buffer, originator, MAX_ORIGINATOR_LENGTH);
     buffer += sizeof(char) * MAX_ORIGINATOR_LENGTH;
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::write: ";
+    buffer << MAX_ORIGINATOR_LENGTH << " byte originator encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= sizeof(char) * MAX_ORIGINATOR_LENGTH;
 
   // Write type field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(type))
+  if((size_t)buffer_remaining >= sizeof(type))
   {
     *(uint32_t*)buffer = madara::utility::endian_swap(type);
     buffer += sizeof(type);
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::write: ";
+    buffer << sizeof(type) << " byte type encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= sizeof(type);
 
   // Write updates field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(updates))
+  if((size_t)buffer_remaining >= sizeof(updates))
   {
     *(uint32_t*)buffer = madara::utility::endian_swap(updates);
     buffer += sizeof(updates);
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::write: ";
+    buffer << sizeof(updates) << " byte updates encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= sizeof(updates);
 
   // Write quality field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(quality))
+  if((size_t)buffer_remaining >= sizeof(quality))
   {
     *(uint32_t*)buffer = madara::utility::endian_swap(quality);
     buffer += sizeof(quality);
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::write: ";
+    buffer << sizeof(quality) << " byte quality encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= sizeof(quality);
 
   // Write clock field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(clock))
+  if((size_t)buffer_remaining >= sizeof(clock))
   {
     *(uint64_t*)buffer = madara::utility::endian_swap(clock);
     buffer += sizeof(clock);
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::write: ";
+    buffer << sizeof(clock) << " byte clock encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= sizeof(clock);
 
   // Write timestamp field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(timestamp))
+  if((size_t)buffer_remaining >= sizeof(timestamp))
   {
     *(uint64_t*)buffer = madara::utility::endian_swap(timestamp);
     buffer += sizeof(timestamp);
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::write: ";
+    buffer << sizeof(timestamp) << " byte timestamp encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= sizeof(timestamp);
 
-  if (buffer_remaining >= 1)
+  if(buffer_remaining >= 1)
   {
     memcpy(buffer, &ttl, 1);
     buffer += 1;
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::write: ";
+    buffer << "1 byte ttl encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= 1;
 
   // Write updates field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(update_number))
+  if((size_t)buffer_remaining >= sizeof(update_number))
   {
     *(uint32_t*)buffer = madara::utility::endian_swap(update_number);
     buffer += sizeof(update_number);
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::write: ";
+    buffer << sizeof(update_number) << " byte update number encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= sizeof(update_number);
+
+  // Write updates field from the buffer and update accordingly
+  if((size_t)buffer_remaining >= sizeof(total_size))
+  {
+    *(uint64_t*)buffer = madara::utility::endian_swap(total_size);
+    buffer += sizeof(total_size);
+  }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "FragmentMessageHeader::write: ";
+    buffer << sizeof(total_size) << " byte total size encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
+  buffer_remaining -= sizeof(total_size);
 
   return buffer;
 }
@@ -242,14 +510,16 @@ bool madara::transport::FragmentMessageHeader::equals(
       dynamic_cast<const FragmentMessageHeader*>(&other);
 
   return size == rhs->size && type == rhs->type && updates == rhs->updates &&
-         update_number == rhs->update_number && quality == rhs->quality &&
+         update_number == rhs->update_number &&
+         total_size == rhs->total_size &&
+         quality == rhs->quality &&
          clock == rhs->clock && timestamp == rhs->timestamp &&
          strncmp(madara_id, rhs->madara_id, MADARA_IDENTIFIER_LENGTH) == 0 &&
          strncmp(domain, rhs->domain, MADARA_DOMAIN_MAX_LENGTH) == 0 &&
          strncmp(originator, rhs->originator, MAX_ORIGINATOR_LENGTH) == 0;
 }
 
-char* madara::transport::defrag(FragmentMap& map)
+char* madara::transport::defrag(FragmentMap& map, uint64_t & total_size)
 {
   char* result = 0;
 
@@ -258,42 +528,47 @@ char* madara::transport::defrag(FragmentMap& map)
       " defragging fragment map\n");
 
   FragmentMap::iterator i = map.find(0);
-  if (i != map.end())
+  if(i != map.end())
   {
     FragmentMessageHeader header;
     int64_t buffer_remaining(header.encoded_size());
-    const char* buffer = header.read(i->second, buffer_remaining);
+    const char* buffer = header.read(i->second.get(), buffer_remaining);
+
+    madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
+        "transport::defrag:"
+        " inspecting frag: %s\n", header.to_string().c_str());
 
     // do we have enough updates to defragment?
-    if (header.updates <= map.size())
+    if(header.updates <= map.size())
     {
       madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
           "transport::defrag:"
           " the map is large enough to contain updates\n");
 
       int64_t size = 0;
-      if (MessageHeader::message_header_test(buffer))
-      {
-        madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
-            "transport::defrag:"
-            " regular message header detected\n");
+      // if(MessageHeader::message_header_test(buffer))
+      // {
+      //   madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
+      //       "transport::defrag:"
+      //       " regular message header detected\n");
 
-        MessageHeader contents_header;
-        buffer_remaining = contents_header.encoded_size();
-        contents_header.read(buffer, buffer_remaining);
-        size = contents_header.size;
-      }
-      else if (ReducedMessageHeader::message_header_test(buffer))
-      {
-        madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
-            "transport::defrag:"
-            " regular message header detected\n");
+      //   MessageHeader contents_header;
+      //   buffer_remaining = contents_header.encoded_size();
+      //   contents_header.read(buffer, buffer_remaining);
+      //   size = contents_header.size;
+      // }
+      // else if(ReducedMessageHeader::message_header_test(buffer))
+      // {
+      //   madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
+      //       "transport::defrag:"
+      //       " reduced message header detected\n");
 
-        ReducedMessageHeader contents_header;
-        buffer_remaining = contents_header.encoded_size();
-        contents_header.read(buffer, buffer_remaining);
-        size = contents_header.size;
-      }
+      //   ReducedMessageHeader contents_header;
+      //   buffer_remaining = contents_header.encoded_size();
+      //   contents_header.read(buffer, buffer_remaining);
+      //   size = contents_header.size;
+      // }
+      size = header.total_size;
 
       result = new char[size];
       char* lhs = result;
@@ -301,7 +576,7 @@ char* madara::transport::defrag(FragmentMap& map)
       uint32_t actual_size = (uint32_t)header.size - header.encoded_size();
       buffer_remaining = actual_size;
 
-      if (size >= 0)
+      if(size >= 0)
       {
         madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
             "transport::defrag: copying buffer to lhs\n");
@@ -312,21 +587,25 @@ char* madara::transport::defrag(FragmentMap& map)
         size -= actual_size;
       }
 
-      if (i != map.end())
+      if(i != map.end())
         ++i;
 
       // if so, iterate over the fragments and copy the contents
-      for (; i != map.end(); ++i)
+      for(; i != map.end(); ++i)
       {
         madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
             "transport::defrag: reading header of new fragment\n");
 
         buffer_remaining = header.encoded_size();
-        buffer = header.read(i->second, buffer_remaining);
-        actual_size = (uint32_t)header.size - header.encoded_size();
+        buffer = header.read(i->second.get(), buffer_remaining);
+        actual_size =(uint32_t)header.size - header.encoded_size();
         buffer_remaining = actual_size;
 
-        if (size >= 0)
+        madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
+            "transport::defrag:"
+            " piecing together frag: %s\n", header.to_string().c_str());
+
+        if(size >= 0)
         {
           madara_logger_ptr_log(logger::global_logger.get(),
               logger::LOG_DETAILED,
@@ -339,6 +618,8 @@ char* madara::transport::defrag(FragmentMap& map)
         }
       }
     }
+
+    total_size = header.total_size;
   }
 
   return result;
@@ -346,18 +627,19 @@ char* madara::transport::defrag(FragmentMap& map)
 
 void madara::transport::delete_fragments(FragmentMap& map)
 {
-  for (FragmentMap::iterator i = map.begin(); i != map.end(); ++i)
+  for(FragmentMap::iterator i = map.begin(); i != map.end(); ++i)
   {
-    delete[] i->second;
+    i->second = (const char*)0;
   }
   map.clear();
 }
 
 char* madara::transport::add_fragment(const char* originator, uint64_t clock,
     uint32_t update_number, const char* fragment, uint32_t queue_length,
-    OriginatorFragmentMap& map, bool clear)
+    OriginatorFragmentMap& map, uint64_t & total_size, bool clear)
 {
   char* result = 0;
+  total_size = 0;
 
   /**
    * add a fragment to the map in the following conditions
@@ -372,7 +654,8 @@ char* madara::transport::add_fragment(const char* originator, uint64_t clock,
   madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_MAJOR,
       "transport::add_fragment: adding fragment\n");
 
-  char* new_fragment = 0;
+  utility::ScopedArray<const char> new_fragment = 0;
+  const char* cur_buffer = fragment;
   FragmentMessageHeader header;
   int64_t buffer_remaining = header.encoded_size();
 
@@ -380,19 +663,27 @@ char* madara::transport::add_fragment(const char* originator, uint64_t clock,
       "transport::add_fragment:"
       " reading header from buffer\n");
 
-  header.read(fragment, buffer_remaining);
+  header.read(cur_buffer, buffer_remaining);
 
-  if (header.size > 0)
+  madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
+      "transport::add_fragment:"
+      " inspecting frag: %s\n", header.to_string().c_str());
+
+  if(header.size > 0)
   {
     madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
         "transport::add_fragment:"
-        " reading header from hold fragment\n");
+        " reading fragment of size %" PRIu64 " into new buffer\n",
+        header.size);
 
-    new_fragment = new char[header.size];
-    memcpy(new_fragment, fragment, header.size);
+    char * new_buffer = new char[header.size];
+    memcpy(new_buffer, fragment, header.size);
+    new_fragment = new_buffer;
   }
   else
+  {
     return 0;
+  }
 
   madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
       "transport::add_fragment:"
@@ -400,17 +691,16 @@ char* madara::transport::add_fragment(const char* originator, uint64_t clock,
       originator);
 
   OriginatorFragmentMap::iterator orig_map = map.find(originator);
-  if (orig_map == map.end())
+  if(orig_map == map.end())
   {
     madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
         "transport::add_fragment:"
         " creating entry for originator %s.\n",
         originator);
 
-    // originator does not exist (1)
+    // originator does not exist(1)
     map[originator][clock][update_number] = new_fragment;
   }
-
   else
   {
     madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
@@ -421,12 +711,12 @@ char* madara::transport::add_fragment(const char* originator, uint64_t clock,
     ClockFragmentMap& clock_map(orig_map->second);
     ClockFragmentMap::iterator clock_found = clock_map.find(clock);
 
-    if (clock_found != clock_map.end())
+    if(clock_found != clock_map.end())
     {
       // we have found the clock entry
-      if (clock_found->second.find(update_number) == clock_found->second.end())
+      if(clock_found->second.find(update_number) == clock_found->second.end())
       {
-        if (clock_found->second.size() != 0)
+        if(clock_found->second.size() != 0)
         {
           madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_MINOR,
               "transport::add_fragment:"
@@ -437,9 +727,9 @@ char* madara::transport::add_fragment(const char* originator, uint64_t clock,
           clock_found->second[update_number] = new_fragment;
 
           // check for a new buffer
-          result = defrag(clock_found->second);
+          result = defrag(clock_found->second, total_size);
 
-          if (result && clear)
+          if(result && clear)
           {
             madara_logger_ptr_log(logger::global_logger.get(),
                 logger::LOG_MINOR,
@@ -450,13 +740,21 @@ char* madara::transport::add_fragment(const char* originator, uint64_t clock,
             delete_fragments(clock_found->second);
             clock_map.erase(clock);
           }
+          else if(result)
+          {
+            madara_logger_ptr_log(logger::global_logger.get(),
+                logger::LOG_MINOR,
+                "transport::add_fragment:"
+                " %s:%d is complete. Not deleting fragments.\n",
+                originator, update_number);
+          }
           else
           {
             madara_logger_ptr_log(logger::global_logger.get(),
                 logger::LOG_MINOR,
                 "transport::add_fragment:"
-                " %s:%d is complete. Need more fragments.\n",
-                originator, update_number);
+                " %s:%d is incomplete. %d size.\n",
+                originator, update_number, (int)clock_found->second.size());
           }
         }
         else
@@ -470,7 +768,7 @@ char* madara::transport::add_fragment(const char* originator, uint64_t clock,
       }
     }
 
-    else if (clock_map.size() < queue_length)
+    else if(clock_map.size() < queue_length)
     {
       // if we get here, the message has already been defragged
       madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_MINOR,
@@ -478,7 +776,7 @@ char* madara::transport::add_fragment(const char* originator, uint64_t clock,
           " %s:%d is being added to queue.\n",
           originator, update_number);
 
-      // clock queue has not been exhausted (2)
+      // clock queue has not been exhausted(2)
       clock_map[clock][update_number] = new_fragment;
     }
     else
@@ -488,9 +786,9 @@ char* madara::transport::add_fragment(const char* originator, uint64_t clock,
           " %s:%d is being added to queue after a deletion\n",
           originator, update_number);
 
-      uint32_t oldest = (uint32_t)clock_map.begin()->first;
+      uint32_t oldest =(uint32_t)clock_map.begin()->first;
 
-      if (oldest < clock)
+      if(oldest < clock)
       {
         madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_MINOR,
             "transport::add_fragment:"
@@ -500,10 +798,10 @@ char* madara::transport::add_fragment(const char* originator, uint64_t clock,
         FragmentMap& fragments = clock_map[oldest];
 
         // delete all fragments in the clock entry
-        for (FragmentMap::iterator i = fragments.begin(); i != fragments.end();
+        for(FragmentMap::iterator i = fragments.begin(); i != fragments.end();
              ++i)
         {
-          delete[] i->second;
+          i->second = (const char*)0;
         }
 
         madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
@@ -525,7 +823,7 @@ char* madara::transport::add_fragment(const char* originator, uint64_t clock,
 
 void madara::transport::FragmentMessageHeader::operator=(MessageHeader& header)
 {
-  if (this != &header)
+  if(this != &header)
   {
     clock = header.clock;
     strncpy(domain, header.domain, MADARA_DOMAIN_MAX_LENGTH);
@@ -540,68 +838,91 @@ void madara::transport::FragmentMessageHeader::operator=(MessageHeader& header)
 }
 
 void madara::transport::frag(
-    const char* source, uint32_t fragment_size, FragmentMap& map)
+    const char* source, uint64_t total_size,
+    const char* originator, const char* domain,
+    uint64_t clock,
+    uint64_t timestamp,
+    uint32_t quality, unsigned char ttl,
+    uint64_t fragment_size, FragmentMap& map)
 {
-  if (fragment_size > 0)
+  if(fragment_size > 0)
   {
     madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_MAJOR,
         "transport::frag:"
         " fragmenting character stream into %d byte packets.\n",
         fragment_size);
 
-    uint32_t data_per_packet =
-        fragment_size - FragmentMessageHeader::static_encoded_size();
+    uint64_t data_per_packet = fragment_size;
+//        fragment_size - FragmentMessageHeader::static_encoded_size();
 
     const char* buffer = source;
-    uint64_t total_size;
     FragmentMessageHeader header;
-    if (MessageHeader::message_header_test(source))
+    header.size = total_size;
+    header.total_size = total_size;
+    strncpy(header.originator, originator, MAX_ORIGINATOR_LENGTH);
+    strncpy(header.domain, domain, MADARA_DOMAIN_MAX_LENGTH);
+    header.clock = clock;
+    header.timestamp = timestamp;
+    header.quality = quality;
+    header.ttl = ttl;
+
+    // if(MessageHeader::message_header_test(source))
+    // {
+    //   madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
+    //       "transport::frag:"
+    //       " regular message header detected\n",
+    //       fragment_size);
+
+    //   MessageHeader contents_header;
+    //   int64_t buffer_remaining = contents_header.encoded_size();
+    //   contents_header.read(source, buffer_remaining);
+    //   header = contents_header;
+    // }
+    // else if(ReducedMessageHeader::message_header_test(source))
+    // {
+    //   madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
+    //       "transport::frag:"
+    //       " reduced message header detected\n");
+
+    //   ReducedMessageHeader contents_header;
+    //   int64_t buffer_remaining = contents_header.encoded_size();
+    //   contents_header.read(source, buffer_remaining);
+    //   header = contents_header;
+    // }
+
+//    total_size = header.size;
+    header.updates =(uint32_t)(total_size / data_per_packet);
+    uint64_t last_size = total_size % data_per_packet;
+
+    if(last_size != 0)
     {
-      madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
-          "transport::frag:"
-          " regular message header detected\n",
-          fragment_size);
-
-      MessageHeader contents_header;
-      int64_t buffer_remaining = contents_header.encoded_size();
-      contents_header.read(source, buffer_remaining);
-      header = contents_header;
-    }
-    else if (ReducedMessageHeader::message_header_test(source))
-    {
-      madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
-          "transport::frag:"
-          " reduced message header detected\n");
-
-      ReducedMessageHeader contents_header;
-      int64_t buffer_remaining = contents_header.encoded_size();
-      contents_header.read(source, buffer_remaining);
-      header = contents_header;
-    }
-
-    total_size = header.size;
-    header.updates = (uint32_t)header.size / data_per_packet;
-
-    if (header.size % data_per_packet != 0)
       ++header.updates;
+    }
 
     madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
         "transport::frag:"
-        " iterating over %d updates.\n",
-        header.updates);
+        " inspecting frag: %s\n", header.to_string().c_str());
 
-    for (uint32_t i = 0; i < header.updates; ++i)
+    madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
+        "transport::frag:"
+        " iterating over %d updates. last_size=%d\n",
+        (int)header.updates, (int)last_size);
+
+    for(uint32_t i = 0; i < header.updates; ++i)
     {
       char* new_frag;
       size_t cur_size;
       int64_t buffer_remaining;
       uint64_t actual_data_size;
 
-      if (i == header.updates - 1)
-        cur_size =
-            (size_t)total_size + FragmentMessageHeader::static_encoded_size();
+      if(i == header.updates - 1 && last_size != 0)
+      {
+        cur_size = (size_t)last_size + FragmentMessageHeader::static_encoded_size();
+      }
       else
-        cur_size = (size_t)fragment_size;
+      {
+        cur_size = (size_t)fragment_size + FragmentMessageHeader::static_encoded_size();
+      }
 
       buffer_remaining = cur_size;
       actual_data_size =
@@ -612,11 +933,17 @@ void madara::transport::frag(
 
       madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
           "transport::frag:"
-          " writing %d packet of size %d.\n",
-          i, cur_size);
+          " writing %d packet of size %d (non-header:%d).\n",
+          (int)i, (int)cur_size, (int)actual_data_size);
 
       header.update_number = i;
       header.size = cur_size;
+
+      madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_DETAILED,
+          "transport::frag:"
+          " inspecting frag: %s\n", header.to_string().c_str());
+
+
       new_frag = header.write(new_frag, buffer_remaining);
       memcpy(new_frag, buffer, (size_t)actual_data_size);
       buffer += actual_data_size;
@@ -632,7 +959,7 @@ bool madara::transport::is_complete(
 
   OriginatorFragmentMap::iterator orig_map = map.find(originator);
 
-  if (orig_map != map.end())
+  if(orig_map != map.end())
   {
     madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_MINOR,
         "transport::is_complete:"
@@ -642,7 +969,7 @@ bool madara::transport::is_complete(
     ClockFragmentMap& clock_map(orig_map->second);
     ClockFragmentMap::iterator clock_found = clock_map.find(clock);
 
-    if (clock_found != clock_map.end())
+    if(clock_found != clock_map.end())
     {
       madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_MINOR,
           "transport::is_complete:"
@@ -652,21 +979,21 @@ bool madara::transport::is_complete(
       uint64_t size = clock_found->second.size();
       FragmentMap::iterator i = clock_found->second.find(0);
 
-      if (i != clock_found->second.end())
+      if(i != clock_found->second.end())
       {
         madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_MINOR,
             "transport::is_complete:"
             " %s:%" PRIu64 ": 0 == fragmap.end.\n",
             originator, clock);
 
-        if (FragmentMessageHeader::get_updates(i->second) == size)
+        if(FragmentMessageHeader::get_updates(i->second.get()) == size)
         {
           madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_MAJOR,
               "transport::is_complete:"
               " %s:%" PRIu64 ": size == %" PRIu64 ", updates == %" PRIu32
               ". COMPLETE\n",
               originator, clock, size,
-              FragmentMessageHeader::get_updates(i->second));
+              FragmentMessageHeader::get_updates(i->second.get()));
 
           result = true;
         }
@@ -677,10 +1004,10 @@ bool madara::transport::is_complete(
               " %s:%" PRIu64 ": size == %" PRIu64 ", updates == %" PRIu32
               ". INCOMPLETE\n",
               originator, clock, size,
-              FragmentMessageHeader::get_updates(i->second));
+              FragmentMessageHeader::get_updates(i->second.get()));
         }
       }
-      else if (size == 0)
+      else if(size == 0)
       {
         madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_MAJOR,
             "transport::is_complete:"
@@ -716,14 +1043,14 @@ bool madara::transport::exists(const char* originator, uint64_t clock,
 
   OriginatorFragmentMap::iterator orig_map = map.find(originator);
 
-  if (orig_map != map.end())
+  if(orig_map != map.end())
   {
     ClockFragmentMap& clock_map(orig_map->second);
     ClockFragmentMap::iterator clock_found = clock_map.find(clock);
 
-    if (clock_found != clock_map.end())
+    if(clock_found != clock_map.end())
     {
-      if (clock_found->second.find(update_number) != clock_found->second.end())
+      if(clock_found->second.find(update_number) != clock_found->second.end())
       {
         result = true;
       }

--- a/include/madara/transport/MessageHeader.cpp
+++ b/include/madara/transport/MessageHeader.cpp
@@ -9,7 +9,7 @@
 
 madara::transport::MessageHeader::MessageHeader()
   : size(encoded_size()),
-    type(0),
+    type(2),
     updates(0),
     quality(0),
     clock(0),
@@ -28,7 +28,7 @@ madara::transport::MessageHeader::~MessageHeader() {}
 uint32_t madara::transport::MessageHeader::encoded_size(void) const
 {
   return sizeof(uint64_t) * 3  // size, clock, timestamp
-         + sizeof(char) * (MADARA_IDENTIFIER_LENGTH + MADARA_DOMAIN_MAX_LENGTH +
+         + sizeof(char) *(MADARA_IDENTIFIER_LENGTH + MADARA_DOMAIN_MAX_LENGTH +
                               MAX_ORIGINATOR_LENGTH + 1) +
          sizeof(uint32_t) * 3;  // type, updates, quality
 }
@@ -36,7 +36,7 @@ uint32_t madara::transport::MessageHeader::encoded_size(void) const
 uint32_t madara::transport::MessageHeader::static_encoded_size(void)
 {
   return sizeof(uint64_t) * 3  // size, clock, timestamp
-         + sizeof(char) * (MADARA_IDENTIFIER_LENGTH + MADARA_DOMAIN_MAX_LENGTH +
+         + sizeof(char) *(MADARA_IDENTIFIER_LENGTH + MADARA_DOMAIN_MAX_LENGTH +
                               MAX_ORIGINATOR_LENGTH + 1) +
          sizeof(uint32_t) * 3;  // type, updates, quality
 }
@@ -45,16 +45,25 @@ const char* madara::transport::MessageHeader::read(
     const char* buffer, int64_t& buffer_remaining)
 {
   // Remove size field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(size))
+  if((size_t)buffer_remaining >= sizeof(size))
   {
     memcpy(&size, buffer, sizeof(size));
     size = madara::utility::endian_swap(size);
     buffer += sizeof(size);
   }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "MessageHeader::read: ";
+    buffer << sizeof(size) << " byte size field cannot fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
+  }
   buffer_remaining -= sizeof(size);
 
   // Remove madara_id field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(char) * MADARA_IDENTIFIER_LENGTH)
+  if((size_t)buffer_remaining >= sizeof(char) * MADARA_IDENTIFIER_LENGTH)
   {
     strncpy(madara_id, buffer, MADARA_IDENTIFIER_LENGTH);
     buffer += sizeof(char) * MADARA_IDENTIFIER_LENGTH;
@@ -72,7 +81,7 @@ const char* madara::transport::MessageHeader::read(
   buffer_remaining -= sizeof(char) * MADARA_IDENTIFIER_LENGTH;
 
   // Remove domain field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(char) * MADARA_DOMAIN_MAX_LENGTH)
+  if((size_t)buffer_remaining >= sizeof(char) * MADARA_DOMAIN_MAX_LENGTH)
   {
     strncpy(domain, buffer, MADARA_DOMAIN_MAX_LENGTH);
     buffer += sizeof(char) * MADARA_DOMAIN_MAX_LENGTH;
@@ -91,7 +100,7 @@ const char* madara::transport::MessageHeader::read(
   buffer_remaining -= sizeof(char) * MADARA_DOMAIN_MAX_LENGTH;
 
   // Remove originator from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(char) * MAX_ORIGINATOR_LENGTH)
+  if((size_t)buffer_remaining >= sizeof(char) * MAX_ORIGINATOR_LENGTH)
   {
     strncpy(originator, buffer, MAX_ORIGINATOR_LENGTH);
     buffer += sizeof(char) * MAX_ORIGINATOR_LENGTH;
@@ -109,7 +118,7 @@ const char* madara::transport::MessageHeader::read(
   buffer_remaining -= sizeof(char) * MAX_ORIGINATOR_LENGTH;
 
   // Remove type field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(type))
+  if((size_t)buffer_remaining >= sizeof(type))
   {
     memcpy(&type, buffer, sizeof(type));
     type = madara::utility::endian_swap(type);
@@ -128,7 +137,7 @@ const char* madara::transport::MessageHeader::read(
   buffer_remaining -= sizeof(type);
 
   // Remove updates field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(updates))
+  if((size_t)buffer_remaining >= sizeof(updates))
   {
     memcpy(&updates, buffer, sizeof(updates));
     updates = madara::utility::endian_swap(updates);
@@ -147,7 +156,7 @@ const char* madara::transport::MessageHeader::read(
   buffer_remaining -= sizeof(updates);
 
   // Remove quality field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(quality))
+  if((size_t)buffer_remaining >= sizeof(quality))
   {
     memcpy(&quality, buffer, sizeof(quality));
     quality = madara::utility::endian_swap(quality);
@@ -166,7 +175,7 @@ const char* madara::transport::MessageHeader::read(
   buffer_remaining -= sizeof(quality);
 
   // Remove clock field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(clock))
+  if((size_t)buffer_remaining >= sizeof(clock))
   {
     memcpy(&clock, buffer, sizeof(clock));
     clock = madara::utility::endian_swap(clock);
@@ -185,7 +194,7 @@ const char* madara::transport::MessageHeader::read(
   buffer_remaining -= sizeof(clock);
 
   // Remove timestamp field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(timestamp))
+  if((size_t)buffer_remaining >= sizeof(timestamp))
   {
     memcpy(&timestamp, buffer, sizeof(timestamp));
     timestamp = madara::utility::endian_swap(timestamp);
@@ -204,7 +213,7 @@ const char* madara::transport::MessageHeader::read(
   buffer_remaining -= sizeof(timestamp);
 
   // Remove the time to live field from the buffer
-  if (buffer_remaining >= 1)
+  if(buffer_remaining >= 1)
   {
     memcpy(&ttl, buffer, 1);
     buffer += 1;
@@ -218,7 +227,7 @@ char* madara::transport::MessageHeader::write(
     char* buffer, int64_t& buffer_remaining)
 {
   // Write size field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(size))
+  if((size_t)buffer_remaining >= sizeof(size))
   {
     *(uint64_t*)buffer = madara::utility::endian_swap(size);
     buffer += sizeof(size);
@@ -236,7 +245,7 @@ char* madara::transport::MessageHeader::write(
   buffer_remaining -= sizeof(size);
 
   // Write madara_id field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(char) * MADARA_IDENTIFIER_LENGTH)
+  if((size_t)buffer_remaining >= sizeof(char) * MADARA_IDENTIFIER_LENGTH)
   {
     strncpy(buffer, madara_id, MADARA_IDENTIFIER_LENGTH);
     buffer += sizeof(char) * MADARA_IDENTIFIER_LENGTH;
@@ -254,7 +263,7 @@ char* madara::transport::MessageHeader::write(
   buffer_remaining -= sizeof(char) * MADARA_IDENTIFIER_LENGTH;
 
   // Write domain field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(char) * MADARA_DOMAIN_MAX_LENGTH)
+  if((size_t)buffer_remaining >= sizeof(char) * MADARA_DOMAIN_MAX_LENGTH)
   {
     strncpy(buffer, domain, MADARA_DOMAIN_MAX_LENGTH);
     buffer += sizeof(char) * MADARA_DOMAIN_MAX_LENGTH;
@@ -272,7 +281,7 @@ char* madara::transport::MessageHeader::write(
   buffer_remaining -= sizeof(char) * MADARA_DOMAIN_MAX_LENGTH;
 
   // Write originator from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(char) * MAX_ORIGINATOR_LENGTH)
+  if((size_t)buffer_remaining >= sizeof(char) * MAX_ORIGINATOR_LENGTH)
   {
     strncpy(buffer, originator, MAX_ORIGINATOR_LENGTH);
     buffer += sizeof(char) * MAX_ORIGINATOR_LENGTH;
@@ -290,7 +299,7 @@ char* madara::transport::MessageHeader::write(
   buffer_remaining -= sizeof(char) * MAX_ORIGINATOR_LENGTH;
 
   // Write type field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(type))
+  if((size_t)buffer_remaining >= sizeof(type))
   {
     *(uint32_t*)buffer = madara::utility::endian_swap(type);
     buffer += sizeof(type);
@@ -308,7 +317,7 @@ char* madara::transport::MessageHeader::write(
   buffer_remaining -= sizeof(type);
 
   // Write updates field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(updates))
+  if((size_t)buffer_remaining >= sizeof(updates))
   {
     *(uint32_t*)buffer = madara::utility::endian_swap(updates);
     buffer += sizeof(updates);
@@ -326,7 +335,7 @@ char* madara::transport::MessageHeader::write(
   buffer_remaining -= sizeof(updates);
 
   // Write quality field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(quality))
+  if((size_t)buffer_remaining >= sizeof(quality))
   {
     *(uint32_t*)buffer = madara::utility::endian_swap(quality);
     buffer += sizeof(quality);
@@ -344,7 +353,7 @@ char* madara::transport::MessageHeader::write(
   buffer_remaining -= sizeof(quality);
 
   // Write clock field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(clock))
+  if((size_t)buffer_remaining >= sizeof(clock))
   {
     *(uint64_t*)buffer = madara::utility::endian_swap(clock);
     buffer += sizeof(clock);
@@ -362,7 +371,7 @@ char* madara::transport::MessageHeader::write(
   buffer_remaining -= sizeof(clock);
 
   // Write timestamp field from the buffer and update accordingly
-  if ((size_t)buffer_remaining >= sizeof(timestamp))
+  if((size_t)buffer_remaining >= sizeof(timestamp))
   {
     *(uint64_t*)buffer = madara::utility::endian_swap(timestamp);
     buffer += sizeof(timestamp);
@@ -379,10 +388,20 @@ char* madara::transport::MessageHeader::write(
   }
   buffer_remaining -= sizeof(timestamp);
 
-  if (buffer_remaining >= 1)
+  if(buffer_remaining >= 1)
   {
     memcpy(buffer, &ttl, 1);
     buffer += 1;
+  }
+  else
+  {
+    std::stringstream buffer;
+    buffer << "MessageHeader::write: ";
+    buffer << "1 byte ttl encoding cannot";
+    buffer << " fit in ";
+    buffer << buffer_remaining << " byte buffer\n";
+
+    throw exceptions::MemoryException(buffer.str());
   }
   buffer_remaining -= 1;
 
@@ -393,23 +412,23 @@ std::string madara::transport::MessageHeader::to_string(void)
 {
   std::stringstream buffer;
 
-  buffer << "140: size (8:" << size << "), ";
-  buffer << "encoding (8:" << madara_id << "), ";
-  buffer << "domain (32:" << domain << "), ";
-  buffer << "orig (64:" << originator << "), ";
-  buffer << "type (4:" << type << "), ";
-  buffer << "numupdates (4:" << updates << "), ";
-  buffer << "quality (4:" << quality << "), ";
-  buffer << "clock (8:" << clock << "), ";
-  buffer << "wallclock (8:" << timestamp << "), ";
-  buffer << "ttl (1:" << (int)ttl << "), ";
+  buffer << "141: size(8:" << size << "), ";
+  buffer << "encoding(8:" << madara_id << "), ";
+  buffer << "domain(32:" << domain << "), ";
+  buffer << "orig(64:" << originator << "), ";
+  buffer << "type(4:" << type << "), ";
+  buffer << "numupdates(4:" << updates << "), ";
+  buffer << "quality(4:" << quality << "), ";
+  buffer << "clock(8:" << clock << "), ";
+  buffer << "wallclock(8:" << timestamp << "), ";
+  buffer << "ttl(1:" <<(int)ttl << "), ";
 
   return buffer.str();
 }
 
 uint64_t madara::transport::MessageHeader::get_size(const char* buffer)
 {
-  return (madara::utility::endian_swap(*(uint64_t*)buffer));
+  return(madara::utility::endian_swap(*(uint64_t*)buffer));
 }
 
 bool madara::transport::MessageHeader::equals(const MessageHeader& other)

--- a/include/madara/transport/MessageHeader.h
+++ b/include/madara/transport/MessageHeader.h
@@ -139,17 +139,33 @@ public:
   /**
    * the identifier of this transport (MADARA_IDENTIFIER)
    **/
-  char madara_id[MADARA_IDENTIFIER_LENGTH];
+  char madara_id[MADARA_IDENTIFIER_LENGTH] = {
+    '\0','\0','\0','\0','\0','\0','\0','\0'
+  };
 
   /**
    * the domain that this message is intended for
    **/
-  char domain[MADARA_DOMAIN_MAX_LENGTH];
+  char domain[MADARA_DOMAIN_MAX_LENGTH] = {
+    '\0','\0','\0','\0','\0','\0','\0','\0',
+    '\0','\0','\0','\0','\0','\0','\0','\0',
+    '\0','\0','\0','\0','\0','\0','\0','\0',
+    '\0','\0','\0','\0','\0','\0','\0','\0'
+  };
 
   /**
    * the originator of the message (host:port)
    **/
-  char originator[MAX_ORIGINATOR_LENGTH];
+  char originator[MAX_ORIGINATOR_LENGTH] = {
+    '\0','\0','\0','\0','\0','\0','\0','\0',
+    '\0','\0','\0','\0','\0','\0','\0','\0',
+    '\0','\0','\0','\0','\0','\0','\0','\0',
+    '\0','\0','\0','\0','\0','\0','\0','\0',
+    '\0','\0','\0','\0','\0','\0','\0','\0',
+    '\0','\0','\0','\0','\0','\0','\0','\0',
+    '\0','\0','\0','\0','\0','\0','\0','\0',
+    '\0','\0','\0','\0','\0','\0','\0','\0'
+  };
 
   /**
    * the type of message @see madara::transport::Messages enum

--- a/include/madara/transport/TransportSettings.h
+++ b/include/madara/transport/TransportSettings.h
@@ -235,7 +235,7 @@ public:
    * fragmented clock values were 1=4GB, 2=4GB, 3=4GB, then you could
    * have 12GB, regardless of max_fragment_size.
    **/
-  uint32_t fragment_queue_length = 5;
+  uint32_t fragment_queue_length = 100;
 
   /// Reliability required of the transport.
   /// See madara::transport::Reliabilities for options

--- a/include/madara/transport/udp/UdpTransport.cpp
+++ b/include/madara/transport/udp/UdpTransport.cpp
@@ -18,10 +18,10 @@ UdpTransport::UdpTransport(const std::string& id,
   : BasicASIOTransport(id, context, config),
     enforcer_(1 / config.max_send_hertz)
 {
-  if (launch_transport)
+  if(launch_transport)
     setup();
 
-  if (config.debug_to_kb_prefix != "")
+  if(config.debug_to_kb_prefix != "")
   {
     knowledge::KnowledgeBase kb;
     kb.use(context);
@@ -57,7 +57,7 @@ int UdpTransport::setup_read_thread(double hertz, const std::string& name)
 
 int UdpTransport::setup_read_socket(void)
 {
-  if (BasicASIOTransport::setup_read_socket() < 0)
+  if(BasicASIOTransport::setup_read_socket() < 0)
   {
     return -1;
   }
@@ -89,7 +89,7 @@ int UdpTransport::setup_read_socket(void)
 
 int UdpTransport::setup_write_socket(void)
 {
-  if (BasicASIOTransport::setup_write_socket() < 0)
+  if(BasicASIOTransport::setup_write_socket() < 0)
   {
     return -1;
   }
@@ -108,7 +108,7 @@ long UdpTransport::send_buffer(
   while (actual_sent < 0 && (settings_.resend_attempts < 0 ||
                                 send_attempts < settings_.resend_attempts))
   {
-    if (settings_.max_send_hertz > 0)
+    if(settings_.max_send_hertz > 0)
     {
       enforcer_.sleep_until_next();
     }
@@ -130,12 +130,12 @@ long UdpTransport::send_buffer(
     }
 
     ++send_attempts;
-    if (settings_.debug_to_kb_prefix != "")
+    if(settings_.debug_to_kb_prefix != "")
     {
       ++sent_packets;
     }
 
-    if (actual_sent > 0)
+    if(actual_sent > 0)
     {
       madara_logger_log(context_.get_logger(), logger::LOG_MAJOR,
           "UdpTransport::send_buffer: Sent %d byte packet to %s:%d\n",
@@ -144,14 +144,14 @@ long UdpTransport::send_buffer(
 
       bytes_sent += actual_sent;
 
-      if (settings_.debug_to_kb_prefix != "")
+      if(settings_.debug_to_kb_prefix != "")
       {
         sent_data += actual_sent;
-        if (sent_data_max < actual_sent)
+        if(sent_data_max < actual_sent)
         {
           sent_data_max = actual_sent;
         }
-        if (sent_data_min > actual_sent || sent_data_min == 0)
+        if(sent_data_min > actual_sent || sent_data_min == 0)
         {
           sent_data_min = actual_sent;
         }
@@ -159,7 +159,7 @@ long UdpTransport::send_buffer(
     }
     else
     {
-      if (settings_.debug_to_kb_prefix != "")
+      if(settings_.debug_to_kb_prefix != "")
       {
         ++failed_sends;
       }
@@ -169,13 +169,14 @@ long UdpTransport::send_buffer(
   return (long)bytes_sent;
 }
 
-long UdpTransport::send_message(const char* buf, size_t packet_size)
+long UdpTransport::send_message(const char* buf, size_t packet_size,
+  uint64_t clock)
 {
   static const char print_prefix[] = "UdpTransport::send_message";
 
   uint64_t bytes_sent = 0;
 
-  if (packet_size > settings_.max_fragment_size)
+  if(packet_size > settings_.max_fragment_size)
   {
     FragmentMap map;
 
@@ -186,27 +187,30 @@ long UdpTransport::send_message(const char* buf, size_t packet_size)
         print_prefix, packet_size, settings_.max_fragment_size);
 
     // fragment the message
-    frag(buf, settings_.max_fragment_size, map);
+    frag(buf, packet_size, id_.c_str (), settings_.write_domain.c_str(),
+      clock, utility::get_time(), 0, 0,
+      settings_.max_fragment_size, map);
 
     int j(0);
-    for (FragmentMap::iterator i = map.begin(); i != map.end(); ++i, ++j)
+    for(FragmentMap::iterator i = map.begin(); i != map.end(); ++i, ++j)
     {
       madara_logger_log(context_.get_logger(), logger::LOG_MAJOR,
           "%s:"
           " Sending fragment %d\n",
           print_prefix, j);
 
-      for (const auto& address : addresses_)
+      for(const auto& address : addresses_)
       {
-        if (pre_send_buffer(&address - &*addresses_.begin()))
+        if(pre_send_buffer(&address - &*addresses_.begin()))
         {
           bytes_sent += send_buffer(
-              address, i->second, (size_t)MessageHeader::get_size(i->second));
+              address, i->second.get(),
+              (size_t)MessageHeader::get_size(i->second.get()));
         }
       }
 
       // sleep between fragments, if such a slack time is specified
-      if (settings_.slack_time > 0)
+      if(settings_.slack_time > 0)
         utility::sleep(settings_.slack_time);
     }
 
@@ -224,7 +228,7 @@ long UdpTransport::send_message(const char* buf, size_t packet_size)
         " Sending packet of size %ld\n",
         print_prefix, packet_size);
 
-    for (const auto& address : addresses_)
+    for(const auto& address : addresses_)
     {
       size_t addr_index = &address - &*addresses_.begin();
       bool should_send = pre_send_buffer(addr_index);
@@ -235,14 +239,14 @@ long UdpTransport::send_message(const char* buf, size_t packet_size)
           print_prefix, address.address().to_string().c_str(),
           (int)address.port(), addr_index, should_send);
 
-      if (should_send)
+      if(should_send)
       {
         bytes_sent += send_buffer(address, buf, (size_t)packet_size);
       }
     }
   }
 
-  if (bytes_sent > 0)
+  if(bytes_sent > 0)
   {
     send_monitor_.add((uint32_t)bytes_sent);
   }
@@ -261,13 +265,14 @@ long UdpTransport::send_data(
   long result(0);
   const char* print_prefix = "UdpTransport::send_data";
 
-  if (!settings_.no_sending)
+  if(!settings_.no_sending && orig_updates.size() != 0)
   {
     result = prep_send(orig_updates, print_prefix);
 
-    if (addresses_.size() > 0 && result > 0)
+    if(addresses_.size() > 0 && result > 0)
     {
-      result = send_message(buffer_.get_ptr(), result);
+      result = send_message(
+          buffer_.get_ptr(), result, orig_updates.begin()->second.clock);
     }
   }
 

--- a/include/madara/transport/udp/UdpTransport.h
+++ b/include/madara/transport/udp/UdpTransport.h
@@ -82,8 +82,9 @@ protected:
   int setup_write_socket() override;
   int setup_read_thread(double hertz, const std::string& name) override;
 
-  long send_message(const char* buf, size_t size);
-  long send_buffer(const udp::endpoint& target, const char* buf, size_t size);
+  long send_message(const char* buf, size_t size, uint64_t clock);
+  long send_buffer(const udp::endpoint& target,
+    const char* buf, size_t size);
   virtual bool pre_send_buffer(size_t addr_index)
   {
     return addr_index != 0;

--- a/include/madara/transport/udp/UdpTransportReadThread.cpp
+++ b/include/madara/transport/udp/UdpTransportReadThread.cpp
@@ -80,14 +80,15 @@ void UdpTransportReadThread::rebroadcast(const char* print_prefix,
   char* buffer = buffer_.get_ptr();
   int result(0);
 
-  if (!settings_.no_sending)
+  if (!settings_.no_sending && records.size () > 0)
   {
     result = prep_rebroadcast(*context_, buffer, buffer_remaining, settings_,
         print_prefix, header, records, transport_.packet_scheduler_);
 
     if (result > 0)
     {
-      result = transport_.send_message(buffer, result);
+      uint64_t clock = records.begin()->second.clock;
+      result = transport_.send_message(buffer, result, clock);
 
       if (result > 0)
       {

--- a/tools/karl.cpp
+++ b/tools/karl.cpp
@@ -358,6 +358,16 @@ void handle_arguments(int argc, const char** argv, size_t recursion_limit = 10)
 
       ++i;
     }
+    else if (arg1 == "-fql" || arg1 == "--fragment-queue-length")
+    {
+      if (i + 1 < argc)
+      {
+        std::stringstream buffer(argv[i + 1]);
+        buffer >> settings.fragment_queue_length;
+      }
+
+      ++i;
+    }
     else if(arg1 == "-h" || arg1 == "--help")
     {
       madara_logger_ptr_log(logger::global_logger.get(), logger::LOG_ALWAYS,
@@ -377,6 +387,8 @@ void handle_arguments(int argc, const char** argv, size_t recursion_limit = 10)
           "  [--debug]                print all sent, received, and final "
           "knowledge\n"
           "  [-f|--logfile file]      log to a file\n"
+          "  [-fql--fragment-queue-length num] the depth of the fragment lst\n"
+          "                           more depth is better for big packets\n"
           "  [-h|--help]              print help menu (i.e., this menu)\n"
           "  [-i|--input file]        file containing MADARA logic to "
           "evaluate\n"
@@ -406,6 +418,7 @@ void handle_arguments(int argc, const char** argv, size_t recursion_limit = 10)
           "  [-ltp|--load-transport-prefix prfx] prefix of saved settings\n"
           "  [-ltt|--load-transport-text file] a text file to load transport "
           "settings from\n"
+          "  [-lz4|--lz4]             compress with LZ4 over network\n"
           "  [-m|--multicast ip:port] the multicast ip to send and listen to\n"
           "  [-n|--capnp tag:msg_type] register tag with given message schema. "
           "See also -nf and -ni.\n"
@@ -445,6 +458,7 @@ void handle_arguments(int argc, const char** argv, size_t recursion_limit = 10)
           "JSON\n"
           "  [-sff|--stream-from file] stream knowledge from a file\n"
           "  [-ss|--save-size bytes]  size of buffer needed for file saves\n"
+          "  [-ssl|--ssl password]    encrypt with 256bit AES over network\n"
           "  [-st|--save-transsport file] a file to save transport settings "
           "to\n"
           "  [-sff|--stream-to file]  stream knowledge to a file\n"


### PR DESCRIPTION
…B datagram boundary)

* Extended Udp transport to deal with FragmentHeader properly
* Still needs to be cleaned up quite a bit
  * Have not analyzed all possible attack surfaces
* Updated network_profiler to include lz4 and ssl options
* Updated test_fragmentation to include ssl fragmentation
* Updated karl with some of the help options it should print out (not done)
* Lots of small improvements throughout the transport layer

Do not merge this. I plan to polish this and check CI with changes.