### PR TITLE
Reverted delay_sending_modifieds default settings to false

### DIFF
--- a/include/madara/knowledge/EvalSettings.h
+++ b/include/madara/knowledge/EvalSettings.h
@@ -67,7 +67,7 @@ struct MADARA_EXPORT EvalSettings : public KnowledgeUpdateSettings
    **/
   EvalSettings()
     : KnowledgeUpdateSettings(),
-      delay_sending_modifieds(true),
+      delay_sending_modifieds(false),
       pre_print_statement(""),
       post_print_statement("")
   {


### PR DESCRIPTION
This fixes simluations (zone denfense simulations were working after this fix)