### PR TITLE
* I believe we have found the actual way to fix readthedocs. It's not…

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,14 +13,7 @@ build:
   tools:
     python: "3.12"
   jobs:
-    pre_install:
-      - pwd
     post_build:
-      - pwd
-      - ls 
-      - ls docs
-      - ls docs/madara
-      - ls _readthedocs
       - cp -rf docs/madara/* _readthedocs/
 
 sphinx:


### PR DESCRIPTION
… pretty. It shouldn't be necessary. But apparently rtd wants us to overwrite everything that we're forced to do with sphinx with our own recursive copy over sphinx's output. This was figured out by doing lots of ls commands and then sleuthing through what rtd is doing. I hope this is the last time I have to do this, but jobs: post_build is the current method we are using